### PR TITLE
Improve network optimization and related systems

### DIFF
--- a/cabin/config-public.go
+++ b/cabin/config-public.go
@@ -70,7 +70,6 @@ var (
 	publicCfgOptionTransports        config.StringArrayOption
 	publicCfgOptionTransportsDefault = []string{
 		"tcp:17",
-		"kcp:17",
 	}
 	publicCfgOptionTransportsOrder = 520
 

--- a/cabin/identity.go
+++ b/cabin/identity.go
@@ -120,9 +120,9 @@ func (id *Identity) MaintainAnnouncement(selfcheck bool) (changed bool, err erro
 		}
 
 		// Apply the status as all other Hubs would in order to check if it's valid.
-		_, _, err = hub.ApplyAnnouncement(id.Hub, newInfoData, conf.MainMapName, conf.MainMapScope, true)
+		_, _, _, err = hub.ApplyAnnouncement(id.Hub, newInfoData, conf.MainMapName, conf.MainMapScope, true)
 		if err != nil {
-			return false, fmt.Errorf("failed to apply new status: %s", err)
+			return false, fmt.Errorf("failed to apply new announcement: %s", err)
 		}
 		id.infoExportCache = newInfoData
 
@@ -192,7 +192,7 @@ func (id *Identity) MaintainStatus(lanes []*hub.Lane, load *int, selfcheck bool)
 		}
 
 		// Apply the status as all other Hubs would in order to check if it's valid.
-		_, _, err = hub.ApplyStatus(id.Hub, newStatusData, conf.MainMapName, conf.MainMapScope, true)
+		_, _, _, err = hub.ApplyStatus(id.Hub, newStatusData, conf.MainMapName, conf.MainMapScope, true)
 		if err != nil {
 			return false, fmt.Errorf("failed to apply new status: %s", err)
 		}

--- a/captain/establish.go
+++ b/captain/establish.go
@@ -46,16 +46,16 @@ func EstablishCrane(ctx context.Context, dst *hub.Hub) (*docks.Crane, error) {
 	return crane, nil
 }
 
-func EstablishPublicLane(ctx context.Context, dst *hub.Hub) (*docks.Crane, error) {
+func EstablishPublicLane(ctx context.Context, dst *hub.Hub) (*docks.Crane, *terminal.Error) {
 	crane, err := EstablishCrane(ctx, dst)
 	if err != nil {
-		return nil, err
+		return nil, terminal.ErrInternalError.With("failed to establish crane: %w", err)
 	}
 
 	// Publish as Lane.
 	publishOp, tErr := NewPublishOp(crane.Controller, publicIdentity)
 	if tErr != nil {
-		return nil, fmt.Errorf("failed to publish: %w", err)
+		return nil, terminal.ErrInternalError.With("failed to publish: %w", err)
 	}
 
 	// Wait for publishing to complete.
@@ -72,7 +72,7 @@ func EstablishPublicLane(ctx context.Context, dst *hub.Hub) (*docks.Crane, error
 		return nil, terminal.ErrStopping
 
 	case <-ctx.Done():
-		return nil, context.Canceled
+		return nil, terminal.ErrCanceled
 	}
 
 	// Query all gossip msgs.

--- a/captain/module.go
+++ b/captain/module.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/safing/portbase/api"
 	"github.com/safing/portbase/config"
+	"github.com/safing/portbase/log"
 	"github.com/safing/portbase/modules"
 	"github.com/safing/portbase/modules/subsystems"
 	"github.com/safing/portbase/rng"
@@ -81,7 +82,7 @@ func start() error {
 		return err
 	}
 	if err := updateSPNIntel(module.Ctx, nil); err != nil {
-		return err
+		log.Errorf("spn/captain: failed to update SPN intel: %s", err)
 	}
 
 	// identity and piers

--- a/captain/navigation.go
+++ b/captain/navigation.go
@@ -280,14 +280,14 @@ optimize:
 		} else if createdConnections < result.MaxConnect {
 			attemptedConnections++
 
-			crane, err := EstablishPublicLane(ctx, connectTo.Hub)
-			if err != nil {
-				log.Warningf("spn/captain: failed to establish lane to %s: %s", connectTo, err)
+			crane, tErr := EstablishPublicLane(ctx, connectTo.Hub)
+			if !tErr.IsOK() {
+				log.Warningf("spn/captain: failed to establish lane to %s: %s", connectTo.Hub, tErr)
 			} else {
 				createdConnections++
 				crane.NetState.UpdateLastSuggestedAt()
 
-				log.Infof("spn/captain: established lane to %s", connectTo)
+				log.Infof("spn/captain: established lane to %s", connectTo.Hub)
 			}
 		}
 	}

--- a/captain/navigation.go
+++ b/captain/navigation.go
@@ -266,7 +266,7 @@ optimize:
 			// Update last suggested timestamp.
 			crane.NetState.UpdateLastSuggestedAt()
 			// Continue crane if stopping.
-			if crane.Stopping.SetToIf(true, false) {
+			if crane.AbortStopping() {
 				log.Infof("spn/captain: optimization aborted retiring of %s, removed stopping mark", crane)
 				crane.NotifyUpdate()
 			}
@@ -308,7 +308,7 @@ optimize:
 			switch {
 			case !crane.IsMine():
 				// Skip cranes built by others.
-			case crane.Stopped() || crane.Stopping.IsSet():
+			case crane.Stopped() || crane.IsStopping():
 				// Skip cranes that are stopped or stopping.
 			case crane.NetState.LastSuggestedAt().After(
 				time.Now().Add(-stopCraneAfterBeingUnsuggestedFor),
@@ -316,7 +316,7 @@ optimize:
 				// Skip cranes that were recently suggested.
 			default:
 				// Mark crane as stopping.
-				if crane.Stopping.SetToIf(false, true) {
+				if crane.MarkStopping() {
 					log.Infof("spn/captain: retiring %s, marked as stopping", crane)
 					crane.NotifyUpdate()
 				}

--- a/captain/navigation.go
+++ b/captain/navigation.go
@@ -260,8 +260,13 @@ optimize:
 	var createdConnections int
 	var attemptedConnections int
 	for _, connectTo := range result.SuggestedConnections {
+		// Skip duplicates.
+		if connectTo.Duplicate {
+			continue
+		}
+
 		// Check if connection already exists.
-		crane := docks.GetAssignedCrane(connectTo.ID)
+		crane := docks.GetAssignedCrane(connectTo.Hub.ID)
 		if crane != nil {
 			// Update last suggested timestamp.
 			crane.NetState.UpdateLastSuggestedAt()
@@ -275,7 +280,7 @@ optimize:
 		} else if createdConnections < result.MaxConnect {
 			attemptedConnections++
 
-			crane, err := EstablishPublicLane(ctx, connectTo)
+			crane, err := EstablishPublicLane(ctx, connectTo.Hub)
 			if err != nil {
 				log.Warningf("spn/captain: failed to establish lane to %s: %s", connectTo, err)
 			} else {

--- a/captain/op_gossip.go
+++ b/captain/op_gossip.go
@@ -8,6 +8,7 @@ import (
 	"github.com/safing/portbase/log"
 	"github.com/safing/spn/conf"
 	"github.com/safing/spn/docks"
+	"github.com/safing/spn/hub"
 	"github.com/safing/spn/terminal"
 )
 
@@ -116,7 +117,11 @@ func (op *GossipOp) Deliver(c *container.Container) *terminal.Error {
 	// Import and verify.
 	h, forward, tErr := docks.ImportAndVerifyHubInfo(module.Ctx, "", announcementData, statusData, conf.MainMapName, conf.MainMapScope)
 	if tErr != nil {
-		log.Warningf("spn/captain: failed to import %s from %s: %s", gossipMsgType, op.controller.Crane.ID, tErr)
+		if tErr.Is(hub.ErrOldData) {
+			log.Debugf("spn/captain: ignoring old %s from %s", gossipMsgType, op.controller.Crane.ID)
+		} else {
+			log.Warningf("spn/captain: failed to import %s from %s: %s", gossipMsgType, op.controller.Crane.ID, tErr)
+		}
 	} else if forward {
 		// Only log if we received something to save/forward.
 		log.Infof("spn/captain: received %s for %s", gossipMsgType, h)

--- a/captain/public.go
+++ b/captain/public.go
@@ -147,7 +147,7 @@ func maintainPublicStatus(ctx context.Context, task *modules.Task) error {
 	lanes := make([]*hub.Lane, 0, len(cranes))
 	for _, crane := range cranes {
 		// Ignore private, stopped or stopping cranes.
-		if !crane.Public() || crane.Stopped() || crane.Stopping.IsSet() {
+		if !crane.Public() || crane.Stopped() || crane.IsStopping() {
 			continue
 		}
 

--- a/crew/op_connect.go
+++ b/crew/op_connect.go
@@ -56,7 +56,7 @@ type ConnectRequest struct {
 	IP        net.IP
 	Protocol  packet.IPProtocol
 	Port      uint16
-	QueueSize uint16
+	QueueSize uint32
 }
 
 func (r *ConnectRequest) Address() string {

--- a/docks/crane.go
+++ b/docks/crane.go
@@ -28,8 +28,6 @@ const (
 	// maxUnloadSize defines the maximum size of a message to unload.
 	maxUnloadSize    = 16384
 	maxSegmentLength = 16384
-
-	CraneMeasurementTTL = 15 * time.Minute
 )
 
 var (

--- a/docks/crane_init.go
+++ b/docks/crane_init.go
@@ -139,7 +139,7 @@ func (crane *Crane) startLocal() *terminal.Error {
 
 	// Create crane controller.
 	_, initData, tErr := NewLocalCraneControllerTerminal(crane, &terminal.TerminalOpts{
-		QueueSize: 100,
+		QueueSize: 10000,
 		Padding:   8,
 	})
 	if tErr != nil {

--- a/docks/crane_netstate.go
+++ b/docks/crane_netstate.go
@@ -11,8 +11,11 @@ const NetStatePeriodInterval = 15 * time.Minute
 type NetworkOptimizationState struct {
 	lock sync.Mutex
 
-	// lastSuggestedAt holds the time when the connnection to the connected Hub was last suggested by the network optimization.
+	// lastSuggestedAt holds the time when the connection to the connected Hub was last suggested by the network optimization.
 	lastSuggestedAt time.Time
+
+	// markedStoppingAt holds the time when the crane was last marked as stopping.
+	markedStoppingAt time.Time
 
 	lifetimeBytesIn  *uint64
 	lifetimeBytesOut *uint64
@@ -45,6 +48,20 @@ func (netState *NetworkOptimizationState) LastSuggestedAt() time.Time {
 	defer netState.lock.Unlock()
 
 	return netState.lastSuggestedAt
+}
+
+func (netState *NetworkOptimizationState) UpdateMarkedStoppingAt() {
+	netState.lock.Lock()
+	defer netState.lock.Unlock()
+
+	netState.markedStoppingAt = time.Now()
+}
+
+func (netState *NetworkOptimizationState) MarkedStoppingAt() time.Time {
+	netState.lock.Lock()
+	defer netState.lock.Unlock()
+
+	return netState.markedStoppingAt
 }
 
 func (netState *NetworkOptimizationState) ReportTraffic(bytes uint64, in bool) {

--- a/docks/crane_verify.go
+++ b/docks/crane_verify.go
@@ -41,7 +41,10 @@ func (crane *Crane) VerifyConnectedHub() error {
 	var reply *container.Container
 	select {
 	case reply = <-crane.unloading:
-	case <-time.After(5 * time.Second):
+	case <-time.After(2 * time.Minute):
+		// Use a big timeout here, as this might keep servers from joining the
+		// network at all, as every servers needs to verify every server, no
+		// matter how far away.
 		return terminal.ErrTimeout.With("waiting for verification reply")
 	case <-crane.ctx.Done():
 		return terminal.ErrShipSunk.With("waiting for verification reply")

--- a/docks/hub_import.go
+++ b/docks/hub_import.go
@@ -74,9 +74,10 @@ func ImportAndVerifyHubInfo(ctx context.Context, hubID string, announcementData,
 		}
 	}
 
-	// Check if the given hub ID matches.
-	if hubID != "" && h.ID != hubID && firstErr == nil {
-		firstErr = terminal.ErrInternalError.With("hub mismatch")
+	// Abort if the given hub ID does not match.
+	// We may have just connected to the wrong IP address.
+	if hubID != "" && h.ID != hubID {
+		return nil, false, terminal.ErrInternalError.With("hub mismatch")
 	}
 
 	// Verify hub if:

--- a/docks/hub_import.go
+++ b/docks/hub_import.go
@@ -33,7 +33,6 @@ func ImportAndVerifyHubInfo(ctx context.Context, hubID string, announcementData,
 	if announcementData != nil {
 		hubFromMsg, known, changed, err := hub.ApplyAnnouncement(nil, announcementData, mapName, scope, false)
 		if err != nil && firstErr == nil {
-			log.Errorf("failed to apply announcement: %w", err)
 			firstErr = terminal.ErrInternalError.With("failed to apply announcement: %w", err)
 		}
 		if known {
@@ -51,7 +50,6 @@ func ImportAndVerifyHubInfo(ctx context.Context, hubID string, announcementData,
 	if statusData != nil {
 		hubFromMsg, known, changed, err := hub.ApplyStatus(h, statusData, mapName, scope, false)
 		if err != nil && firstErr == nil {
-			log.Errorf("failed to apply status: %w", err)
 			firstErr = terminal.ErrInternalError.With("failed to apply status: %w", err)
 		}
 		if known && announcementData == nil {

--- a/docks/measurements.go
+++ b/docks/measurements.go
@@ -10,6 +10,19 @@ import (
 	"github.com/safing/spn/terminal"
 )
 
+const (
+	CraneMeasurementTTLDefault    = 30 * time.Minute
+	CraneMeasurementTTLByCostBase = 1 * time.Minute
+	CraneMeasurementTTLByCostMin  = 30 * time.Minute
+	CraneMeasurementTTLByCostMax  = 3 * time.Hour
+
+	// With a base TTL of 1m, this leads to:
+	// 20c     -> 20m -> raised to 30m
+	// 50c     -> 50m
+	// 100c    -> 1h40m
+	// 1000c   -> 16h40m -> capped to 3h.
+)
+
 // MeasureHub measures the connection to this Hub and saves the results to the
 // Hub.
 func MeasureHub(ctx context.Context, h *hub.Hub, checkExpiryWith time.Duration) *terminal.Error {

--- a/docks/metrics.go
+++ b/docks/metrics.go
@@ -332,7 +332,7 @@ func getCraneStats() *craneGauges {
 		switch {
 		case crane.Stopped():
 			continue
-		case crane.Stopping.IsSet():
+		case crane.IsStopping():
 			craneStats.stoppingActive++
 			continue
 		case crane.Public():

--- a/docks/op_capacity.go
+++ b/docks/op_capacity.go
@@ -16,7 +16,7 @@ import (
 const (
 	CapacityTestOpType = "capacity"
 
-	defaultCapacityTestVolume = 25000000  // 25MB
+	defaultCapacityTestVolume = 50000000  // 50MB
 	maxCapacityTestVolume     = 100000000 // 100MB
 
 	defaultCapacityTestMaxTime = 5 * time.Second

--- a/docks/op_capacity.go
+++ b/docks/op_capacity.go
@@ -16,7 +16,7 @@ import (
 const (
 	CapacityTestOpType = "capacity"
 
-	defaultCapacityTestVolume = 50000000  // 50MB
+	defaultCapacityTestVolume = 25000000  // 25MB
 	maxCapacityTestVolume     = 100000000 // 100MB
 
 	defaultCapacityTestMaxTime = 5 * time.Second

--- a/docks/op_sync_state.go
+++ b/docks/op_sync_state.go
@@ -11,11 +11,6 @@ import (
 
 const (
 	SyncStateOpType = "sync/state"
-
-	SyncStateNonceSize     = 16
-	SyncStateRuns          = 10
-	SyncStatePauseDuration = 1 * time.Second
-	SyncStateOpTimeout     = SyncStateRuns * SyncStatePauseDuration * 3
 )
 
 type SyncStateOp struct {

--- a/docks/op_sync_state.go
+++ b/docks/op_sync_state.go
@@ -1,0 +1,136 @@
+package docks
+
+import (
+	"context"
+	"time"
+
+	"github.com/safing/portbase/container"
+	"github.com/safing/portbase/formats/dsd"
+	"github.com/safing/spn/terminal"
+)
+
+const (
+	SyncStateOpType = "sync/state"
+
+	SyncStateNonceSize     = 16
+	SyncStateRuns          = 10
+	SyncStatePauseDuration = 1 * time.Second
+	SyncStateOpTimeout     = SyncStateRuns * SyncStatePauseDuration * 3
+)
+
+type SyncStateOp struct {
+	terminal.OpBase
+	t      terminal.OpTerminal
+	result chan *terminal.Error
+}
+
+type SyncStateMessage struct {
+	Stopping bool
+}
+
+func (op *SyncStateOp) Type() string {
+	return SyncStateOpType
+}
+
+func init() {
+	terminal.RegisterOpType(terminal.OpParams{
+		Type:     SyncStateOpType,
+		Requires: terminal.IsCraneController,
+		RunOp:    runSyncStateOp,
+	})
+}
+
+func (controller *CraneControllerTerminal) SyncState(ctx context.Context) *terminal.Error {
+	// Check if we own the crane and it is public.
+	if !controller.Crane.IsMine() || !controller.Crane.Public() {
+		return nil
+	}
+
+	// Create and init.
+	op := &SyncStateOp{
+		t:      controller,
+		result: make(chan *terminal.Error, 1),
+	}
+	op.OpBase.Init()
+
+	// Create sync message.
+	msg := &SyncStateMessage{
+		Stopping: controller.Crane.stopping.IsSet(),
+	}
+	data, err := dsd.Dump(msg, dsd.CBOR)
+	if err != nil {
+		return terminal.ErrInternalError.With("%w", err)
+	}
+
+	// Send message.
+	tErr := controller.OpInit(op, container.New(data))
+	if tErr != nil {
+		return tErr
+	}
+
+	// Wait for reply
+	select {
+	case tErr = <-op.result:
+		if tErr.IsError() {
+			return tErr
+		}
+		return nil
+	case <-ctx.Done():
+		return nil
+	case <-time.After(1 * time.Minute):
+		return terminal.ErrTimeout.With("timed out while waiting for sync crane result")
+	}
+}
+
+func runSyncStateOp(t terminal.OpTerminal, opID uint32, data *container.Container) (terminal.Operation, *terminal.Error) {
+	// Check if we are a on a crane controller.
+	var ok bool
+	var controller *CraneControllerTerminal
+	if controller, ok = t.(*CraneControllerTerminal); !ok {
+		return nil, terminal.ErrIncorrectUsage.With("can only be used with a crane controller")
+	}
+
+	// Check if we don't own the crane, but it is public.
+	if controller.Crane.IsMine() || !controller.Crane.Public() {
+		return nil, terminal.ErrPermissinDenied.With("only public lane owner may change the crane status")
+	}
+
+	// Load message.
+	syncState := &SyncStateMessage{}
+	_, err := dsd.Load(data.CompileData(), syncState)
+	if err != nil {
+		return nil, terminal.ErrMalformedData.With("failed to load sync state message: %w", err)
+	}
+
+	// Apply sync state.
+	var changed bool
+	if syncState.Stopping {
+		if controller.Crane.stopping.SetToIf(false, true) {
+			changed = true
+		}
+	} else {
+		if controller.Crane.stopping.SetToIf(true, false) {
+			changed = true
+		}
+	}
+
+	// Notify of change.
+	if changed {
+		controller.Crane.NotifyUpdate()
+	}
+
+	return nil, nil
+}
+
+func (op *SyncStateOp) Deliver(c *container.Container) *terminal.Error {
+	return terminal.ErrIncorrectUsage
+}
+
+func (op *SyncStateOp) End(tErr *terminal.Error) {
+	if op.result != nil {
+		select {
+		case op.result <- tErr:
+		default:
+		}
+	}
+}

--- a/hub/errors.go
+++ b/hub/errors.go
@@ -14,4 +14,7 @@ var (
 
 	// ErrTemporaryValidationError is returned when a validation error might be temporary.
 	ErrTemporaryValidationError = errors.New("temporary validation error")
+
+	// ErrOldData is returned when received data is outdated.
+	ErrOldData = errors.New("")
 )

--- a/hub/intel.go
+++ b/hub/intel.go
@@ -41,6 +41,9 @@ type Intel struct {
 	// Regions defines regions to assist network optimization.
 	Regions []*RegionConfig
 
+	// VirtualNetworks holds network configurations for virtual cloud networks.
+	VirtualNetworks []*VirtualNetworkConfig
+
 	parsed *ParsedIntel
 }
 
@@ -78,6 +81,16 @@ type RegionConfig struct {
 	// InternalMaxHops specifies the max hop constraint for internally optimizing
 	// the region.
 	InternalMaxHops int
+}
+
+// VirtualNetworkConfig holds configuration of a virtual network that binds multiple Hubs together.
+type VirtualNetworkConfig struct {
+	// Name is a human readable name of the virtual network.
+	Name string
+	// Force forces the use of the mapped IP addresses after the Hub's IPs have been verified.
+	Force bool
+	// Mapping maps Hub IDs to internal IP addresses.
+	Mapping map[string]net.IP
 }
 
 // ParsedIntel holds a collection of parsed intel data.

--- a/hub/intel.go
+++ b/hub/intel.go
@@ -38,7 +38,46 @@ type Intel struct {
 	// InfoOverrides is used to override certain Hub information.
 	InfoOverrides map[string]*InfoOverride
 
+	// Regions defines regions to assist network optimization.
+	Regions []*RegionConfig
+
 	parsed *ParsedIntel
+}
+
+// RegionConfig holds the configuration of a region.
+type RegionConfig struct {
+	// ID is the internal identifier of the region.
+	ID string
+	// Name is a human readable name of the region.
+	Name string
+	// MemberPolicy specifies a list for including members.
+	MemberPolicy []string
+
+	// RegionalMinLanes specifies how many lanes other regions should build
+	// to this region.
+	RegionalMinLanes int
+	// RegionalMinLanesPerHub specifies how many lanes other regions should
+	// build to this region, per Hub in this region.
+	// This value will usually be below one.
+	RegionalMinLanesPerHub float64
+	// RegionalMaxLanesOnHub specifies how many lanes from or to another region may be
+	// built on one Hub per region.
+	RegionalMaxLanesOnHub int
+
+	// SatelliteMinLanes specifies how many lanes satellites (Hubs without
+	// region) should build to this region.
+	SatelliteMinLanes int
+	// SatelliteMinLanesPerHub specifies how many lanes satellites (Hubs without
+	// region) should build to this region, per Hub in this region.
+	// This value will usually be below one.
+	SatelliteMinLanesPerHub float64
+
+	// InternalMinLanesOnHub specifies how many lanes every Hub should create
+	// within the region at minimum.
+	InternalMinLanesOnHub int
+	// InternalMaxHops specifies the max hop constraint for internally optimizing
+	// the region.
+	InternalMaxHops int
 }
 
 // ParsedIntel holds a collection of parsed intel data.

--- a/hub/update.go
+++ b/hub/update.go
@@ -73,26 +73,26 @@ func SignHubMsg(msg []byte, env *jess.Envelope, enableTofu bool) ([]byte, error)
 // OpenHubMsg opens a signed hub msg and verifies the signature using the
 // provided hub or the local database. If TOFU is enabled, the signature is
 // always accepted, if valid.
-func OpenHubMsg(hub *Hub, data []byte, mapName string, tofu bool) (msg []byte, sendingHub *Hub, err error) {
+func OpenHubMsg(hub *Hub, data []byte, mapName string, tofu bool) (msg []byte, sendingHub *Hub, known bool, err error) {
 	letter, err := jess.LetterFromDSD(data)
 	if err != nil {
-		return nil, nil, fmt.Errorf("malformed letter: %s", err)
+		return nil, nil, false, fmt.Errorf("malformed letter: %s", err)
 	}
 
 	// check signatures
 	var seal *jess.Seal
 	switch len(letter.Signatures) {
 	case 0:
-		return nil, nil, errors.New("missing signature")
+		return nil, nil, false, errors.New("missing signature")
 	case 1:
 		seal = letter.Signatures[0]
 	default:
-		return nil, nil, fmt.Errorf("too many signatures (%d)", len(letter.Signatures))
+		return nil, nil, false, fmt.Errorf("too many signatures (%d)", len(letter.Signatures))
 	}
 
 	// check signature signer ID
 	if seal.ID == "" {
-		return nil, nil, errors.New("signature is missing signer ID")
+		return nil, nil, false, errors.New("signature is missing signer ID")
 	}
 
 	// get hub for public key
@@ -100,24 +100,28 @@ func OpenHubMsg(hub *Hub, data []byte, mapName string, tofu bool) (msg []byte, s
 		hub, err = GetHub(mapName, seal.ID)
 		if err != nil {
 			if err != database.ErrNotFound {
-				return nil, nil, fmt.Errorf("failed to get existing hub %s: %s", seal.ID, err)
+				return nil, nil, false, fmt.Errorf("failed to get existing hub %s: %s", seal.ID, err)
 			}
 			hub = nil
+		} else {
+			known = true
 		}
+	} else {
+		known = true
 	}
 
 	var truststore jess.TrustStore
 	if hub != nil && hub.PublicKey != nil { // bootstrap entries will not have a public key
 		// check ID integrity
 		if hub.ID != seal.ID {
-			return nil, nil, fmt.Errorf("ID mismatch with hub msg ID %s and hub ID %s", seal.ID, hub.ID)
+			return nil, hub, known, fmt.Errorf("ID mismatch with hub msg ID %s and hub ID %s", seal.ID, hub.ID)
 		}
 		if !verifyHubID(seal.ID, hub.PublicKey.Scheme, hub.PublicKey.Key) {
-			return nil, nil, fmt.Errorf("ID integrity of %s violated with existing key", seal.ID)
+			return nil, hub, known, fmt.Errorf("ID integrity of %s violated with existing key", seal.ID)
 		}
 	} else {
 		if !tofu {
-			return nil, nil, fmt.Errorf("hub msg ID %s unknown (missing announcement)", seal.ID)
+			return nil, nil, false, fmt.Errorf("hub msg ID %s unknown (missing announcement)", seal.ID)
 		}
 
 		// trust on first use, extract key from keys
@@ -127,16 +131,16 @@ func OpenHubMsg(hub *Hub, data []byte, mapName string, tofu bool) (msg []byte, s
 		var pubkey *jess.Seal
 		switch len(letter.Keys) {
 		case 0:
-			return nil, nil, fmt.Errorf("missing key for TOFU of %s", seal.ID)
+			return nil, nil, false, fmt.Errorf("missing key for TOFU of %s", seal.ID)
 		case 1:
 			pubkey = letter.Keys[0]
 		default:
-			return nil, nil, fmt.Errorf("too many keys (%d) for TOFU of %s", len(letter.Keys), seal.ID)
+			return nil, nil, false, fmt.Errorf("too many keys (%d) for TOFU of %s", len(letter.Keys), seal.ID)
 		}
 
 		// check ID integrity
 		if !verifyHubID(seal.ID, seal.Scheme, pubkey.Value) {
-			return nil, nil, fmt.Errorf("ID integrity of %s violated with new key", seal.ID)
+			return nil, nil, false, fmt.Errorf("ID integrity of %s violated with new key", seal.ID)
 		}
 
 		hub = &Hub{
@@ -151,7 +155,7 @@ func OpenHubMsg(hub *Hub, data []byte, mapName string, tofu bool) (msg []byte, s
 		}
 		err = hub.PublicKey.LoadKey()
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, false, err
 		}
 	}
 
@@ -164,10 +168,10 @@ func OpenHubMsg(hub *Hub, data []byte, mapName string, tofu bool) (msg []byte, s
 	// check signature
 	err = letter.Verify(hubMsgRequirements, truststore)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, false, err
 	}
 
-	return letter.Data, hub, nil
+	return letter.Data, hub, known, nil
 }
 
 // Export exports the announcement with the given signature configuration.
@@ -183,18 +187,39 @@ func (ha *Announcement) Export(env *jess.Envelope) ([]byte, error) {
 
 // ApplyAnnouncement applies the announcement to the Hub if it passes all the
 // checks. If no Hub is provided, it is loaded from the database or created.
-func ApplyAnnouncement(hub *Hub, data []byte, mapName string, scope Scope, selfcheck bool) (_ *Hub, forward bool, err error) {
+func ApplyAnnouncement(existingHub *Hub, data []byte, mapName string, scope Scope, selfcheck bool) (hub *Hub, known, changed bool, err error) {
+	// Set valid/invalid status based on the return error.
+	var announcement *Announcement
+	defer func() {
+		if hub != nil {
+			if err != nil && !errors.Is(err, ErrOldData) {
+				hub.InvalidInfo = true
+			} else {
+				hub.InvalidInfo = false
+			}
+		}
+	}()
+
 	// open and verify
-	msg, hub, err := OpenHubMsg(hub, data, mapName, true)
+	var msg []byte
+	msg, hub, known, err = OpenHubMsg(existingHub, data, mapName, true)
+
+	// Lock hub if we have one.
+	if hub != nil && !selfcheck {
+		hub.Lock()
+		defer hub.Unlock()
+	}
+
+	// Check if there was an error with the Hub msg.
 	if err != nil {
-		return nil, false, err
+		return
 	}
 
 	// parse
-	announcement := &Announcement{}
+	announcement = &Announcement{}
 	_, err = dsd.Load(msg, announcement)
 	if err != nil {
-		return nil, false, err
+		return
 	}
 
 	// integrity check
@@ -204,7 +229,8 @@ func ApplyAnnouncement(hub *Hub, data []byte, mapName string, scope Scope, selfc
 	// a signed version of the ID to mitigate fake IDs.
 	// Fake IDs are possible because the hash algorithm of the ID is dynamic.
 	if hub.ID != announcement.ID {
-		return nil, false, fmt.Errorf("announcement ID %q mismatches hub ID %q", announcement.ID, hub.ID)
+		err = fmt.Errorf("announcement ID %q mismatches hub ID %q", announcement.ID, hub.ID)
+		return
 	}
 
 	// version check
@@ -214,21 +240,31 @@ func ApplyAnnouncement(hub *Hub, data []byte, mapName string, scope Scope, selfc
 		case announcement.Timestamp == hub.Info.Timestamp && !selfcheck:
 			// The new copy is not saved, as we expect the versions to be identical.
 			// Also, the new version has not been validated at this point.
-			return hub, false, nil
+			return
 		case announcement.Timestamp < hub.Info.Timestamp:
 			// Received an old version, do not update.
-			return hub, false, fmt.Errorf(
-				"announcement from %s @ %s is older than current status @ %s",
-				hub, time.Unix(announcement.Timestamp, 0), time.Unix(hub.Info.Timestamp, 0),
+			err = fmt.Errorf(
+				"%wannouncement from %s @ %s is older than current status @ %s",
+				ErrOldData, hub, time.Unix(announcement.Timestamp, 0), time.Unix(hub.Info.Timestamp, 0),
 			)
+			return
 		}
+	}
+
+	// We received a new version.
+	changed = true
+
+	// Update timestamp here already in case validation fails.
+	if hub.Info != nil {
+		hub.Info.Timestamp = announcement.Timestamp
 	}
 
 	// Validate the announcement.
 	err = hub.validateAnnouncement(announcement, scope)
 	if err != nil {
 		if selfcheck || hub.FirstSeen.IsZero() {
-			return nil, false, fmt.Errorf("failed to validate announcement of %s: %w", hub, err)
+			err = fmt.Errorf("failed to validate announcement of %s: %w", hub, err)
+			return
 		}
 
 		log.Warningf("received an invalid announcement of %s: %s", hub, err)
@@ -239,25 +275,16 @@ func ApplyAnnouncement(hub *Hub, data []byte, mapName string, scope Scope, selfc
 		// until the issue is fixed.
 	}
 
-	// Apply the result to the Hub.
-	if !selfcheck {
-		hub.Lock()
-		defer hub.Unlock()
-	}
-
-	// Only save announcement if it is valid, else mark it as invalid.
+	// Only save announcement if it is valid.
 	if err == nil {
 		hub.Info = announcement
-		hub.InvalidInfo = false
-	} else {
-		hub.InvalidInfo = true
 	}
 	// Set FirstSeen timestamp when we see this Hub for the first time.
 	if hub.FirstSeen.IsZero() {
 		hub.FirstSeen = time.Now().UTC()
 	}
 
-	return hub, true, nil
+	return
 }
 
 func (hub *Hub) validateAnnouncement(announcement *Announcement, scope Scope) error {
@@ -349,18 +376,38 @@ func (hs *Status) Export(env *jess.Envelope) ([]byte, error) {
 }
 
 // ApplyStatus applies a status update if it passes all the checks.
-func ApplyStatus(hub *Hub, data []byte, mapName string, scope Scope, selfcheck bool) (_ *Hub, forward bool, err error) {
+func ApplyStatus(existingHub *Hub, data []byte, mapName string, scope Scope, selfcheck bool) (hub *Hub, known, changed bool, err error) {
+	// Set valid/invalid status based on the return error.
+	defer func() {
+		if hub != nil {
+			if err != nil && !errors.Is(err, ErrOldData) {
+				hub.InvalidStatus = true
+			} else {
+				hub.InvalidStatus = false
+			}
+		}
+	}()
+
 	// open and verify
-	msg, hub, err := OpenHubMsg(hub, data, mapName, false)
+	var msg []byte
+	msg, hub, known, err = OpenHubMsg(existingHub, data, mapName, false)
+
+	// Lock hub if we have one.
+	if hub != nil && !selfcheck {
+		hub.Lock()
+		defer hub.Unlock()
+	}
+
+	// Check if there was an error with the Hub msg.
 	if err != nil {
-		return nil, false, err
+		return
 	}
 
 	// parse
 	status := &Status{}
 	_, err = dsd.Load(msg, status)
 	if err != nil {
-		return nil, false, err
+		return
 	}
 
 	// version check
@@ -370,21 +417,31 @@ func ApplyStatus(hub *Hub, data []byte, mapName string, scope Scope, selfcheck b
 		case status.Timestamp == hub.Status.Timestamp && !selfcheck:
 			// The new copy is not saved, as we expect the versions to be identical.
 			// Also, the new version has not been validated at this point.
-			return hub, false, nil
+			return
 		case status.Timestamp < hub.Status.Timestamp:
 			// Received an old version, do not update.
-			return hub, false, fmt.Errorf(
-				"status from %s @ %s is older than current status @ %s",
-				hub, time.Unix(status.Timestamp, 0), time.Unix(hub.Status.Timestamp, 0),
+			err = fmt.Errorf(
+				"%wstatus from %s @ %s is older than current status @ %s",
+				ErrOldData, hub, time.Unix(status.Timestamp, 0), time.Unix(hub.Status.Timestamp, 0),
 			)
+			return
 		}
+	}
+
+	// We received a new version.
+	changed = true
+
+	// Update timestamp here already in case validation fails.
+	if hub.Status != nil {
+		hub.Status.Timestamp = status.Timestamp
 	}
 
 	// Validate the status.
 	err = hub.validateStatus(status)
 	if err != nil {
 		if selfcheck {
-			return nil, false, fmt.Errorf("failed to validate status of %s: %w", hub, err)
+			err = fmt.Errorf("failed to validate status of %s: %w", hub, err)
+			return
 		}
 
 		log.Warningf("spn/hub: received an invalid status of %s: %s", hub, err)
@@ -395,21 +452,12 @@ func ApplyStatus(hub *Hub, data []byte, mapName string, scope Scope, selfcheck b
 		// until the issue is fixed.
 	}
 
-	// Apply the result to the Hub.
-	if !selfcheck {
-		hub.Lock()
-		defer hub.Unlock()
-	}
-
 	// Only save status if it is valid, else mark it as invalid.
 	if err == nil {
 		hub.Status = status
-		hub.InvalidStatus = false
-	} else {
-		hub.InvalidStatus = true
 	}
 
-	return hub, true, nil
+	return
 }
 
 func (hub *Hub) validateStatus(status *Status) error {

--- a/hub/update_test.go
+++ b/hub/update_test.go
@@ -61,7 +61,7 @@ func TestHubUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _, err = OpenHubMsg(nil, data, "test", true)
+	_, _, _, err = OpenHubMsg(nil, data, "test", true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/navigator/api.go
+++ b/navigator/api.go
@@ -230,11 +230,13 @@ func handleMapOptimizationTableRequest(ar *api.Request) (data []byte, err error)
 			var mine string
 			switch {
 			case crane.IsMine() && crane.IsStopping():
-				mine = "yes (stopping)"
+				mine = fmt.Sprintf("yes (stopping since %s)",
+					time.Since(crane.NetState.MarkedStoppingAt().Truncate(time.Minute)))
 			case crane.IsMine():
 				mine = "yes"
 			case !crane.IsMine() && crane.IsStopping():
-				mine = "(stopping)"
+				mine = fmt.Sprintf("(stopping since %s)",
+					time.Since(crane.NetState.MarkedStoppingAt().Truncate(time.Minute)))
 			case !crane.IsMine():
 				mine = ""
 			}
@@ -329,11 +331,13 @@ func handleMapMeasurementsTableRequest(ar *api.Request) (data []byte, err error)
 			var mine string
 			switch {
 			case crane.IsMine() && crane.IsStopping():
-				mine = "yes (stopping)"
+				mine = fmt.Sprintf("yes (stopping since %s)",
+					time.Since(crane.NetState.MarkedStoppingAt().Truncate(time.Minute)))
 			case crane.IsMine():
 				mine = "yes"
 			case !crane.IsMine() && crane.IsStopping():
-				mine = "(stopping)"
+				mine = fmt.Sprintf("(stopping since %s)",
+					time.Since(crane.NetState.MarkedStoppingAt().Truncate(time.Minute)))
 			case !crane.IsMine():
 				mine = ""
 			}

--- a/navigator/api.go
+++ b/navigator/api.go
@@ -213,7 +213,7 @@ func handleMapMeasurementsTableRequest(ar *api.Request) (data []byte, err error)
 			var mine string
 			if crane.IsMine() {
 				mine = "yes"
-				if crane.Stopping.IsSet() {
+				if crane.IsStopping() {
 					mine += " (stopping)"
 				}
 			}

--- a/navigator/costs.go
+++ b/navigator/costs.go
@@ -46,13 +46,13 @@ func CalculateLaneCost(latency time.Duration, capacity int) (cost float32) {
 func CalculateHubCost(load int) (cost float32) {
 	switch {
 	case load >= 100:
-		return 1000
+		return 10000
 	case load >= 95:
-		return 100
+		return 1000
 	case load >= 80:
-		return 50
+		return 500
 	default:
-		return 10
+		return 100
 	}
 }
 

--- a/navigator/costs.go
+++ b/navigator/costs.go
@@ -15,13 +15,13 @@ func CalculateLaneCost(latency time.Duration, capacity int) (cost float32) {
 		cost += float32(latency) / float32(time.Millisecond)
 	} else {
 		// Add cautious default cost if latency is not available.
-		cost += 100
+		cost += 1000
 	}
 
 	switch {
 	case capacity == 0:
 		// Add cautious default cost if capacity is not available.
-		cost += 400
+		cost += 4000
 	case capacity < cap1Mbit:
 		// - Between 1000 and 10000 points for ranges below 1Mbit/s
 		cost += 1000 + 9000*((cap1Mbit-float32(capacity))/cap1Mbit)

--- a/navigator/intel.go
+++ b/navigator/intel.go
@@ -24,11 +24,14 @@ func (m *Map) UpdateIntel(update *hub.Intel) error {
 	// Update the map's reference to the intel data.
 	m.intel = update
 
-	// go through map
+	// Update pins with new intel data.
 	for _, pin := range m.all {
 		m.updateIntelStatuses(pin)
 		m.updateInfoOverrides(pin)
 	}
+
+	// Configure the map's regions.
+	m.updateRegions(m.intel.Regions)
 
 	log.Infof("spn/navigator: updated intel on map %s", m.Name)
 

--- a/navigator/map.go
+++ b/navigator/map.go
@@ -16,8 +16,9 @@ type Map struct {
 	sync.RWMutex
 	Name string
 
-	all   map[string]*Pin
-	intel *hub.Intel
+	all     map[string]*Pin
+	intel   *hub.Intel
+	regions []*Region
 
 	home         *Pin
 	homeTerminal *docks.CraneTerminal
@@ -25,9 +26,10 @@ type Map struct {
 	measuringEnabled bool
 	hubUpdateHook    *database.RegisteredHook
 
-	// analysisLock guards access to all of this map's Pin.analysis and the
-	// lastDesegrationAttempt fields.
+	// analysisLock guards access to all of this map's Pin.analysis,
+	// regardedPins and the lastDesegrationAttempt fields.
 	analysisLock           sync.Mutex
+	regardedPins           []*Pin
 	lastDesegrationAttempt time.Time
 }
 

--- a/navigator/module.go
+++ b/navigator/module.go
@@ -61,6 +61,7 @@ func start() error {
 
 		// Only register metrics on Hubs, as they only make sense there.
 		registerMetrics()
+
 	}
 
 	return nil

--- a/navigator/optimize_region.go
+++ b/navigator/optimize_region.go
@@ -1,0 +1,232 @@
+package navigator
+
+import (
+	"fmt"
+	"sort"
+)
+
+func (or *OptimizationResult) markSuggestedReachableInRegion(suggested *Pin, hopDistance int) {
+	// Abort if suggested Pin has no region.
+	if suggested.region == nil {
+		return
+	}
+
+	// Don't update if distance is greater or equal than than current one.
+	if hopDistance >= suggested.analysis.SuggestedHopDistanceInRegion {
+		return
+	}
+
+	// Set suggested hop distance.
+	suggested.analysis.SuggestedHopDistanceInRegion = hopDistance
+
+	// Increase distance and apply to matching Pins.
+	hopDistance++
+	for _, lane := range suggested.ConnectedTo {
+		if lane.Pin.region != nil &&
+			lane.Pin.region.ID == suggested.region.ID &&
+			or.matcher(lane.Pin) {
+			or.markSuggestedReachableInRegion(lane.Pin, hopDistance)
+		}
+	}
+}
+
+func (m *Map) optimizeForLowestCostInRegion(result *OptimizationResult) error {
+	if m.home == nil || m.home.region == nil {
+		return nil
+	}
+	region := m.home.region
+
+	// Add approach.
+	result.addApproach(fmt.Sprintf("Connect to best (lowest cost) %d Hubs within the region.", region.internalMinLanesOnHub))
+
+	// Sort by lowest cost.
+	sort.Sort(sortByLowestMeasuredCost(region.regardedPins))
+
+	// Add to suggested pins.
+	if len(region.regardedPins) <= region.internalMinLanesOnHub {
+		result.addSuggested("best in region", region.regardedPins...)
+	} else {
+		result.addSuggested("best in region", region.regardedPins[:region.internalMinLanesOnHub]...)
+	}
+
+	return nil
+}
+
+func (m *Map) optimizeForDistanceConstraintInRegion(result *OptimizationResult, max int) error {
+	if m.home == nil || m.home.region == nil {
+		return nil
+	}
+	region := m.home.region
+
+	// Add approach.
+	result.addApproach(fmt.Sprintf("Satisfy max hop constraint of %d within the region.", region.internalMaxHops))
+
+	for i := 0; i < max; i++ {
+		// Sort by lowest cost.
+		sort.Sort(sortBySuggestedHopDistanceInRegionAndLowestMeasuredCost(region.regardedPins))
+
+		// Return when all regarded Pins are within the distance constraint.
+		if region.regardedPins[0].analysis.SuggestedHopDistanceInRegion <= region.internalMaxHops {
+			return nil
+		}
+
+		// If not, suggest a connection to the best match.
+		result.addSuggested("satisfy regional hop constraint", region.regardedPins[0])
+	}
+
+	return nil
+}
+
+func (m *Map) optimizeForRegionConnectivity(result *OptimizationResult) error {
+	if m.home == nil || m.home.region == nil {
+		return nil
+	}
+	region := m.home.region
+
+	// Add approach.
+	result.addApproach("Connect region to other regions.")
+
+	// Optimize for every region.
+checkRegions:
+	for _, otherRegion := range m.regions {
+		// Skip own region.
+		if region.ID == otherRegion.ID {
+			continue
+		}
+
+		// Collect data on connections to that region.
+		lanesToRegion, highestCostWithinLaneLimit := m.countConnectionsToRegion(result, region, otherRegion)
+
+		// Sort by lowest cost.
+		sort.Sort(sortByLowestMeasuredCost(otherRegion.regardedPins))
+
+		// Find cheapest connections with a free slot or better values.
+		var lanesSuggested int
+		for _, pin := range otherRegion.regardedPins {
+			myCost := pin.measurements.GetCalculatedCost()
+
+			// Check if we are done or region is satisfied.
+			switch {
+			case lanesSuggested >= region.regionalMaxLanesOnHub:
+				// We hit our max.
+				continue checkRegions
+			case lanesToRegion >= otherRegion.regionalMinLanes && myCost >= highestCostWithinLaneLimit:
+				// Region has enough lanes and we are not better.
+				continue checkRegions
+			}
+
+			// Check if we can contribute on this Pin.
+			switch {
+			case pin.analysis.CrossRegionalConnections < otherRegion.regionalMaxLanesOnHub &&
+				lanesToRegion < otherRegion.regionalMinLanes:
+				// There is a free spot on this Pin and the region needs more connections.
+				result.addSuggested("occupy cross-region lane on pin", pin)
+				lanesSuggested++
+				lanesToRegion++
+				// Because our own Pin is not counted, this should be the default
+				// suggestion for a stable network.
+
+			case myCost < pin.analysis.CrossRegionalHighestCostInHubLimit:
+				// We have a better connection to this Pin than at least one other existing connection (within the limit!).
+				result.addSuggested("replace cross-region lane on pin", pin)
+				lanesSuggested++
+				lanesToRegion++
+
+			case myCost < highestCostWithinLaneLimit &&
+				pin.analysis.CrossRegionalConnections < otherRegion.regionalMaxLanesOnHub:
+				// We have a better connection to this Pin than another existing region-to-region connection.
+				result.addSuggested("replace unrelated cross-region lane", pin)
+				lanesSuggested++
+				lanesToRegion++
+			}
+		}
+	}
+
+	return nil
+}
+
+// countConnectionsToRegion analyzes existing lanes from this to another
+// region, with taking lanes from this Hub into account.
+func (m *Map) countConnectionsToRegion(result *OptimizationResult, region *Region, otherRegion *Region) (lanesToRegion int, highestCostWithinLaneLimit float32) {
+	for _, pin := range region.regardedPins {
+		// Skip self.
+		if m.home.Hub.ID == pin.Hub.ID {
+			continue
+		}
+
+		// Find lanes to other region.
+		for _, lane := range pin.ConnectedTo {
+			if lane.Pin.region != nil &&
+				lane.Pin.region.ID == otherRegion.ID &&
+				result.matcher(lane.Pin) {
+				// This is a lane from this region to a regarded Pin in the other region.
+				lanesToRegion++
+
+				// Count cross region connection.
+				lane.Pin.analysis.CrossRegionalConnections++
+
+				// Collect lane costs.
+				lane.Pin.analysis.CrossRegionalLaneCosts = append(
+					lane.Pin.analysis.CrossRegionalLaneCosts,
+					lane.Cost,
+				)
+			}
+		}
+	}
+
+	// Calculate lane costs from collected lane costs.
+	for _, pin := range otherRegion.regardedPins {
+		sort.Sort(sortCostsByLowest(pin.analysis.CrossRegionalLaneCosts))
+		switch {
+		case len(pin.analysis.CrossRegionalLaneCosts) == 0:
+			// Nothing to do.
+		case len(pin.analysis.CrossRegionalLaneCosts) < otherRegion.regionalMaxLanesOnHub:
+			pin.analysis.CrossRegionalLowestCostLane = pin.analysis.CrossRegionalLaneCosts[0]
+			pin.analysis.CrossRegionalHighestCostInHubLimit = pin.analysis.CrossRegionalLaneCosts[len(pin.analysis.CrossRegionalLaneCosts)-1]
+		default:
+			pin.analysis.CrossRegionalLowestCostLane = pin.analysis.CrossRegionalLaneCosts[0]
+			pin.analysis.CrossRegionalHighestCostInHubLimit = pin.analysis.CrossRegionalLaneCosts[otherRegion.regionalMaxLanesOnHub-1]
+		}
+
+		// Find highest cost within limit.
+		if pin.analysis.CrossRegionalHighestCostInHubLimit > highestCostWithinLaneLimit {
+			highestCostWithinLaneLimit = pin.analysis.CrossRegionalHighestCostInHubLimit
+		}
+	}
+
+	return
+}
+
+func (m *Map) optimizeForSatelliteConnectivity(result *OptimizationResult) error {
+	if m.home == nil {
+		return nil
+	}
+	// This is only for Hubs that are not in a region.
+	if m.home.region != nil {
+		return nil
+	}
+
+	// Add approach.
+	result.addApproach("Connect satellite to regions.")
+
+	// Optimize for every region.
+	for _, region := range m.regions {
+		// Sort by lowest cost.
+		sort.Sort(sortByLowestMeasuredCost(region.regardedPins))
+
+		// Add to suggested pins.
+		if len(region.regardedPins) <= region.satelliteMinLanes {
+			result.addSuggested(fmt.Sprintf("best to region %s", region.ID), region.regardedPins...)
+		} else {
+			result.addSuggested(fmt.Sprintf("best to region %s", region.ID), region.regardedPins[:region.satelliteMinLanes]...)
+		}
+	}
+
+	return nil
+}
+
+type sortCostsByLowest []float32
+
+func (a sortCostsByLowest) Len() int           { return len(a) }
+func (a sortCostsByLowest) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a sortCostsByLowest) Less(i, j int) bool { return a[i] < a[j] }

--- a/navigator/pin.go
+++ b/navigator/pin.go
@@ -56,6 +56,9 @@ type Pin struct {
 	// analysis holds the analysis state.
 	// Should only be set during analysis and be reset at the start and removed at the end of an analysis.
 	analysis *AnalysisState
+
+	// region is the region this Pin belongs to.
+	region *Region
 }
 
 // PinConnection represents a connection to a terminal on the Hub.

--- a/navigator/pin.go
+++ b/navigator/pin.go
@@ -168,9 +168,6 @@ func (pin *Pin) hasActiveTerminal() bool {
 }
 
 func (pin *Pin) NotifyTerminalChange() {
-	if !pin.HasActiveTerminal() {
-		pin.pushChanges.Set()
-	}
-
+	pin.pushChanges.Set()
 	pin.pushChange()
 }

--- a/navigator/region.go
+++ b/navigator/region.go
@@ -1,0 +1,230 @@
+package navigator
+
+import (
+	"context"
+	"math"
+
+	"github.com/apex/log"
+	"github.com/safing/portmaster/profile/endpoints"
+	"github.com/safing/spn/hub"
+)
+
+const (
+	defaultRegionalMinLanesPerHub  = 0.5
+	defaultRegionalMaxLanesOnHub   = 2
+	defaultSatelliteMinLanesPerHub = 0.3
+	defaultInternalMinLanesOnHub   = 3
+	defaultInternalMaxHops         = 3
+)
+
+type Region struct {
+	ID           string
+	Name         string
+	config       *hub.RegionConfig
+	memberPolicy endpoints.Endpoints
+
+	pins         []*Pin
+	regardedPins []*Pin
+
+	regionalMinLanes      int
+	regionalMaxLanesOnHub int
+	satelliteMinLanes     int
+	internalMinLanesOnHub int
+	internalMaxHops       int
+}
+
+func (region *Region) getName() string {
+	switch {
+	case region == nil:
+		return "-"
+	case region.Name != "":
+		return region.Name
+	default:
+		return region.ID
+	}
+}
+
+func (m *Map) updateRegions(config []*hub.RegionConfig) {
+	// Reset map and pins.
+	m.regions = make([]*Region, 0, len(config))
+	for _, pin := range m.all {
+		pin.region = nil
+	}
+
+	// Stop if not regions are defined.
+	if len(config) == 0 {
+		return
+	}
+
+	// Build regions from config.
+	for _, regionConfig := range config {
+		// Check if region has an ID.
+		if regionConfig.ID == "" {
+			log.Error("navigator: region is missing ID")
+			// Abort adding this region to the map.
+			continue
+		}
+
+		// Create new region.
+		region := &Region{
+			ID:     regionConfig.ID,
+			Name:   regionConfig.Name,
+			config: regionConfig,
+		}
+
+		// Parse member policy.
+		if len(regionConfig.MemberPolicy) == 0 {
+			log.Errorf("navigator: member policy of region %s is missing", region.ID)
+			// Abort adding this region to the map.
+			continue
+		}
+		memberPolicy, err := endpoints.ParseEndpoints(regionConfig.MemberPolicy)
+		if err != nil {
+			log.Errorf("navigator: failed to parse member policy of region %s: %w", region.ID, err)
+			// Abort adding this region to the map.
+			continue
+		}
+		region.memberPolicy = memberPolicy
+
+		// Recalculate region properties.
+		region.recalculateProperties()
+
+		// Add region to map.
+		m.regions = append(m.regions, region)
+	}
+
+	// Update region in all Pins.
+	for _, pin := range m.all {
+		m.updatePinRegion(pin)
+	}
+}
+
+func (region *Region) addPin(pin *Pin) {
+	// Find pin in region.
+	for _, regionPin := range region.pins {
+		if pin.Hub.ID == regionPin.Hub.ID {
+			// Pin is already part of region.
+			return
+		}
+	}
+
+	// Check if pin is already part of this region.
+	if pin.region != nil && pin.region.ID == region.ID {
+		return
+	}
+
+	// Remove pin from previous region.
+	if pin.region != nil {
+		pin.region.removePin(pin)
+	}
+
+	// Add new pin to region.
+	region.pins = append(region.pins, pin)
+	pin.region = region
+
+	// Recalculate region properties.
+	region.recalculateProperties()
+}
+
+func (region *Region) removePin(pin *Pin) {
+	// Find pin index in region.
+	removeIndex := -1
+	for index, regionPin := range region.pins {
+		if pin.Hub.ID == regionPin.Hub.ID {
+			removeIndex = index
+			break
+		}
+	}
+	if removeIndex < 0 {
+		// Pin is not part of region.
+		return
+	}
+
+	// Remove pin from region.
+	region.pins = append(region.pins[:removeIndex], region.pins[removeIndex+1:]...)
+
+	// Recalculate region properties.
+	region.recalculateProperties()
+}
+
+func (region *Region) recalculateProperties() {
+	// Regional properties.
+	region.regionalMinLanes = calculateMinLanes(
+		len(region.pins),
+		region.config.RegionalMinLanes,
+		region.config.RegionalMinLanesPerHub,
+		defaultRegionalMinLanesPerHub,
+	)
+	region.regionalMaxLanesOnHub = region.config.RegionalMaxLanesOnHub
+	if region.regionalMaxLanesOnHub <= 0 {
+		region.regionalMaxLanesOnHub = defaultRegionalMaxLanesOnHub
+	}
+
+	// Satellite properties.
+	region.satelliteMinLanes = calculateMinLanes(
+		len(region.pins),
+		region.config.SatelliteMinLanes,
+		region.config.SatelliteMinLanesPerHub,
+		defaultSatelliteMinLanesPerHub,
+	)
+
+	// Internal properties.
+	region.internalMinLanesOnHub = region.config.InternalMinLanesOnHub
+	if region.internalMinLanesOnHub <= 0 {
+		region.internalMinLanesOnHub = defaultInternalMinLanesOnHub
+	}
+	region.internalMaxHops = region.config.InternalMaxHops
+	if region.internalMaxHops <= 0 {
+		region.internalMaxHops = defaultInternalMaxHops
+	}
+	// Values below 2 do not make any sense for max hops.
+	if region.internalMaxHops < 2 {
+		region.internalMaxHops = 2
+	}
+}
+
+func calculateMinLanes(regionHubCount, minLanes int, minLanesPerHub, defaultMinLanesPerHub float64) (minLaneCount int) {
+	// Validate hub count.
+	if regionHubCount <= 0 {
+		// Reset to safe value.
+		regionHubCount = 1
+	}
+
+	// Set to configured minimum lanes.
+	minLaneCount = minLanes
+
+	// Raise to configured minimum lanes per Hub.
+	if minLanesPerHub != 0 {
+		minLanesFromSize := int(math.Ceil(float64(regionHubCount) * minLanesPerHub))
+		if minLanesFromSize > minLaneCount {
+			minLaneCount = minLanesFromSize
+		}
+	}
+
+	// Raise to default minimum lanes per Hub, if still 0.
+	if minLaneCount <= 0 {
+		minLaneCount = int(math.Ceil(float64(regionHubCount) * defaultMinLanesPerHub))
+	}
+
+	return minLaneCount
+}
+
+func (m *Map) updatePinRegion(pin *Pin) {
+	for _, region := range m.regions {
+		// Check if pin matches the region's member policy.
+		if pin.EntityV4 != nil {
+			result, _ := region.memberPolicy.Match(context.TODO(), pin.EntityV4)
+			if result == endpoints.Permitted {
+				region.addPin(pin)
+				return
+			}
+		}
+		if pin.EntityV6 != nil {
+			result, _ := region.memberPolicy.Match(context.TODO(), pin.EntityV6)
+			if result == endpoints.Permitted {
+				region.addPin(pin)
+				return
+			}
+		}
+	}
+}

--- a/navigator/region.go
+++ b/navigator/region.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/apex/log"
+	"github.com/safing/portbase/log"
 	"github.com/safing/portmaster/profile/endpoints"
 	"github.com/safing/spn/hub"
 )

--- a/navigator/sort.go
+++ b/navigator/sort.go
@@ -56,6 +56,36 @@ func (a sortBySuggestedHopDistanceAndLowestMeasuredCost) Less(i, j int) bool {
 	return a[i].Hub.ID < a[j].Hub.ID
 }
 
+type sortBySuggestedHopDistanceInRegionAndLowestMeasuredCost []*Pin
+
+func (a sortBySuggestedHopDistanceInRegionAndLowestMeasuredCost) Len() int { return len(a) }
+func (a sortBySuggestedHopDistanceInRegionAndLowestMeasuredCost) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+func (a sortBySuggestedHopDistanceInRegionAndLowestMeasuredCost) Less(i, j int) bool {
+	// First sort by suggested hop distance.
+	if a[i].analysis.SuggestedHopDistanceInRegion != a[j].analysis.SuggestedHopDistanceInRegion {
+		return a[i].analysis.SuggestedHopDistanceInRegion > a[j].analysis.SuggestedHopDistanceInRegion
+	}
+
+	// Then by cost.
+	x := a[i].measurements.GetCalculatedCost()
+	y := a[j].measurements.GetCalculatedCost()
+	if x != y {
+		return x < y
+	}
+
+	// Fall back to geo proximity.
+	gx := a[i].measurements.GetGeoProximity()
+	gy := a[j].measurements.GetGeoProximity()
+	if gx != gy {
+		return gx > gy
+	}
+
+	// Fall back to Hub ID.
+	return a[i].Hub.ID < a[j].Hub.ID
+}
+
 type sortByLowestMeasuredLatency []*Pin
 
 func (a sortByLowestMeasuredLatency) Len() int      { return len(a) }

--- a/ships/kcp.go
+++ b/ships/kcp.go
@@ -18,12 +18,15 @@ type KCPPier struct {
 	PierBase
 }
 
+// TODO: Find a replacement for kcp, which turned out to not fit our use case.
+/*
 func init() {
 	Register("kcp", &Builder{
 		LaunchShip:    launchKCPShip,
 		EstablishPier: establishKCPPier,
 	})
 }
+*/
 
 func launchKCPShip(ctx context.Context, transport *hub.Transport, ip net.IP) (Ship, error) {
 	conn, err := kcp.Dial(net.JoinHostPort(ip.String(), portToA(transport.Port)))

--- a/ships/tcp.go
+++ b/ships/tcp.go
@@ -27,7 +27,7 @@ func init() {
 
 func launchTCPShip(ctx context.Context, transport *hub.Transport, ip net.IP) (Ship, error) {
 	dialer := &net.Dialer{
-		Timeout: 3 * time.Second,
+		Timeout: 30 * time.Second,
 	}
 	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(ip.String(), portToA(transport.Port)))
 	if err != nil {

--- a/ships/virtual_network.go
+++ b/ships/virtual_network.go
@@ -1,0 +1,40 @@
+package ships
+
+import (
+	"net"
+	"sync"
+
+	"github.com/safing/spn/hub"
+)
+
+var (
+	virtNetLock   sync.Mutex
+	virtNetConfig *hub.VirtualNetworkConfig
+)
+
+func SetVirtualNetworkConfig(config *hub.VirtualNetworkConfig) {
+	virtNetLock.Lock()
+	defer virtNetLock.Unlock()
+
+	virtNetConfig = config
+}
+
+func GetVirtualNetworkConfig() *hub.VirtualNetworkConfig {
+	virtNetLock.Lock()
+	defer virtNetLock.Unlock()
+
+	return virtNetConfig
+}
+
+func GetVirtualNetworkAddress(dstHubID string) net.IP {
+	virtNetLock.Lock()
+	defer virtNetLock.Unlock()
+
+	// Check if we have a virtual network config.
+	if virtNetConfig == nil {
+		return nil
+	}
+
+	// Return mapping for given Hub ID.
+	return virtNetConfig.Mapping[dstHubID]
+}

--- a/terminal/errors.go
+++ b/terminal/errors.go
@@ -171,17 +171,7 @@ func registerError(id uint8, err error) *Error {
 // }
 
 func (e *Error) IsOK() bool {
-	if e == nil || e.err == nil {
-		return true
-	}
-	switch e.id {
-	case 2: // ErrStopping
-		return true
-	case 3: // ErrExplicitAck
-		return true
-	default:
-		return false
-	}
+	return !e.IsError()
 }
 
 func (e *Error) IsError() bool {
@@ -199,11 +189,10 @@ var (
 	// ErrUnknownError is the default error.
 	ErrUnknownError = registerError(0, errors.New("unknown error"))
 
-	// Error IDs 1-7 are reserved for special values.
+	// Error IDs 1-7 are reserved for special "OK" values.
 
-	ErrStopping      = registerError(2, errors.New("stopping"))
-	ErrExplicitAck   = registerError(3, errors.New("explicit ack"))
-	ErrTryAgainLater = registerError(4, errors.New("try again later"))
+	ErrStopping    = registerError(2, errors.New("stopping"))
+	ErrExplicitAck = registerError(3, errors.New("explicit ack"))
 
 	// Errors IDs 8 and up are for regular errors.
 
@@ -222,6 +211,7 @@ var (
 	ErrHubUnavailable         = registerError(101, errors.New("hub unavailable"))
 	ErrShipSunk               = registerError(108, errors.New("ship sunk"))
 	ErrDestinationUnavailable = registerError(113, errors.New("destination unavailable"))
+	ErrTryAgainLater          = registerError(114, errors.New("try again later"))
 	ErrConnectionError        = registerError(121, errors.New("connection error"))
 	ErrQueueOverflow          = registerError(122, errors.New("queue overflowed"))
 	ErrCanceled               = registerError(125, context.Canceled)

--- a/terminal/flow_queue.go
+++ b/terminal/flow_queue.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	DefaultQueueSize        = 1000
-	MaxQueueSize            = 10000
+	MaxQueueSize            = 60000
 	forceReportBelowPercent = 0.75
 )
 
@@ -51,7 +51,7 @@ type DuplexFlowQueue struct {
 
 func NewDuplexFlowQueue(
 	ti TerminalInterface,
-	queueSize uint16,
+	queueSize uint32,
 	submitUpstream func(*container.Container),
 ) *DuplexFlowQueue {
 	dfq := &DuplexFlowQueue{

--- a/terminal/init.go
+++ b/terminal/init.go
@@ -33,7 +33,7 @@ const (
 // TerminalOpts holds configuration for the terminal.
 type TerminalOpts struct {
 	Version   uint8  `json:"-"`
-	QueueSize uint16 `json:"qs,omitempty"`
+	QueueSize uint32 `json:"qs,omitempty"`
 	Padding   uint16 `json:"p,omitempty"`
 	Encrypt   bool   `json:"e,omitempty"`
 }

--- a/terminal/terminal_test.go
+++ b/terminal/terminal_test.go
@@ -149,7 +149,7 @@ func TestTerminals(t *testing.T) {
 }
 
 func TestTerminalsWithEncryption(t *testing.T) {
-	var testQueueSize uint16 = DefaultQueueSize
+	var testQueueSize uint32 = DefaultQueueSize
 	countToQueueSize := uint64(testQueueSize)
 
 	initMsg := &TerminalOpts{


### PR DESCRIPTION
- Increase timeouts related to verifying Hubs
- Improve pin update order
- Add support for discontinued Hubs, fix Hub deletion
- Make measurement TTL dynamic to save bandwidth
- Reduce default capacity test volume to 25MB
- Remove unnecessary check
- Sync crane status to connected Hub
- Update QueueSize to uint32 and increase controller queue size
- Disable kcp until we find a replacement
- Don't die when the intel update fails on startup
- Add time limit to stopping cranes
- Increase capacity test volume to 50MB again
- Raise hub costs to better match lane costs
- Add regions for optimization
