### PR TITLE
Stop SPN client manager correctly when not yet connected

### DIFF
--- a/captain/hooks.go
+++ b/captain/hooks.go
@@ -8,8 +8,12 @@ import (
 	"github.com/safing/spn/docks"
 )
 
-func initDockHooks() {
+func startDockHooks() {
 	docks.RegisterCraneUpdateHook(handleCraneUpdate)
+}
+
+func stopDockHooks() {
+	docks.ResetCraneUpdateHook()
 }
 
 func handleCraneUpdate(crane *docks.Crane) {

--- a/captain/module.go
+++ b/captain/module.go
@@ -99,8 +99,8 @@ func start() error {
 		crew.EnableConnecting(publicIdentity.Hub)
 	}
 
-	// Subscribe to updates of connections.
-	initDockHooks()
+	// Subscribe to updates of cranes.
+	startDockHooks()
 
 	// bootstrapping
 	if err := processBootstrapHubFlag(); err != nil {
@@ -128,6 +128,9 @@ func start() error {
 func stop() error {
 	// Reset intel resource so that it is loaded again when starting.
 	resetSPNIntel()
+
+	// Unregister crane update hook.
+	stopDockHooks()
 
 	// Send shutdown status message.
 	if conf.PublicHub() {

--- a/captain/navigation.go
+++ b/captain/navigation.go
@@ -135,6 +135,7 @@ func connectToHomeHub(ctx context.Context, dst *hub.Hub) error {
 	select {
 	case <-gossipQuery.ctx.Done():
 	case <-ctx.Done():
+		return context.Canceled
 	}
 
 	// Create communication terminal.


### PR DESCRIPTION
- Stop SPN client manager correctly when not yet connected
- Reset crane update hook when stopping SPN
