### PR TITLE
Fix crane hooks and udp socket options

### DIFF
--- a/captain/hooks.go
+++ b/captain/hooks.go
@@ -17,6 +17,10 @@ func stopDockHooks() {
 }
 
 func handleCraneUpdate(crane *docks.Crane) {
+	if crane == nil {
+		return
+	}
+
 	if conf.Client() && crane.Controller != nil && crane.Controller.Abandoning.IsSet() {
 		// Check connection to home hub.
 		triggerClientHealthCheck()

--- a/docks/cranehooks.go
+++ b/docks/cranehooks.go
@@ -33,6 +33,10 @@ func ResetCraneUpdateHook() {
 
 // NotifyUpdate calls the registers crane update hook function.
 func (crane *Crane) NotifyUpdate() {
+	if crane == nil {
+		return
+	}
+
 	craneUpdateHookLock.Lock()
 	defer craneUpdateHookLock.Unlock()
 

--- a/sluice/packet_listener.go
+++ b/sluice/packet_listener.go
@@ -37,7 +37,7 @@ func ListenPacket(network, address string) (net.Listener, error) {
 		newConns: make(chan *PacketConn),
 		conns:    make(map[string]*PacketConn),
 	}
-	module.StartWorker("packet listener reader", ln.reader)
+	module.StartServiceWorker("packet listener reader", 0, ln.reader)
 	module.StartServiceWorker("packet listener cleaner", time.Minute, ln.cleaner)
 
 	return ln, nil


### PR DESCRIPTION
- Add nil guards to crane hooks
- Do not special UDP socket options on windows
