### PR TITLE
Errors and logging improvements

### DIFF
--- a/captain/client.go
+++ b/captain/client.go
@@ -20,8 +20,7 @@ import (
 )
 
 var (
-	bootstrapped = abool.New()
-	ready        = abool.New()
+	ready = abool.New()
 
 	spnLoginButton = notifications.Action{
 		Text:    "Login",
@@ -39,12 +38,6 @@ var (
 		Payload: "https://account.safing.io",
 	}
 )
-
-// ClientBootstrapping signifies if the SPN is currently bootstrapping and
-// requires normal connectivity for download assets.
-func ClientBootstrapping() bool {
-	return bootstrapped.IsNotSet()
-}
 
 // ClientReady signifies if the SPN client is fully ready to handle connections.
 func ClientReady() bool {
@@ -84,7 +77,6 @@ func triggerClientHealthCheck() {
 func clientManager(ctx context.Context) error {
 	defer func() {
 		ready.UnSet()
-		bootstrapped.UnSet()
 		netenv.ConnectedToSPN.UnSet()
 		resetSPNStatus(StatusDisabled, true)
 		module.Resolve("")

--- a/captain/navigation.go
+++ b/captain/navigation.go
@@ -159,7 +159,7 @@ func connectToHomeHub(ctx context.Context, dst *hub.Hub) error {
 			return tErr.Wrap("failed to authenticate to")
 		}
 	case <-time.After(3 * time.Second):
-		return terminal.ErrTimeout.With("timed out waiting for auth to complete")
+		return terminal.ErrTimeout.With("waiting for auth to complete")
 	case <-ctx.Done():
 		return terminal.ErrStopping
 	}

--- a/captain/op_gossip.go
+++ b/captain/op_gossip.go
@@ -142,6 +142,7 @@ func (op *GossipOp) Deliver(c *container.Container) *terminal.Error {
 }
 
 // End ends the operation.
-func (op *GossipOp) End(err *terminal.Error) {
+func (op *GossipOp) End(err *terminal.Error) (errorToSend *terminal.Error) {
 	deleteGossipOp(op.controller.Crane.ID)
+	return err
 }

--- a/captain/op_gossip_query.go
+++ b/captain/op_gossip_query.go
@@ -181,9 +181,10 @@ func (op *GossipQueryOp) Deliver(c *container.Container) *terminal.Error {
 }
 
 // End ends the operation.
-func (op *GossipQueryOp) End(err *terminal.Error) {
+func (op *GossipQueryOp) End(err *terminal.Error) (errorToSend *terminal.Error) {
 	if op.client {
 		log.Infof("spn/captain: gossip query imported %d entries", op.importCnt)
 	}
 	op.cancelCtx()
+	return err
 }

--- a/captain/op_publish.go
+++ b/captain/op_publish.go
@@ -154,7 +154,7 @@ func (op *PublishOp) Result() <-chan *terminal.Error {
 }
 
 // End ends the operation.
-func (op *PublishOp) End(tErr *terminal.Error) {
+func (op *PublishOp) End(tErr *terminal.Error) (errorToSend *terminal.Error) {
 	if tErr.Is(terminal.ErrExplicitAck) {
 		// TODO: Check for concurrenct access.
 		if op.controller.Crane.ConnectedHub == nil {
@@ -175,4 +175,5 @@ func (op *PublishOp) End(tErr *terminal.Error) {
 	case op.result <- tErr:
 	default:
 	}
+	return tErr
 }

--- a/crew/connect.go
+++ b/crew/connect.go
@@ -289,7 +289,7 @@ func establishRoute(route *navigator.Route) (dstPin *navigator.Pin, dstTerminal 
 				return nil, nil, tErr.Wrap("failed to authenticate to %s", check.pin.Hub)
 			}
 		case <-time.After(3 * time.Second):
-			return nil, nil, terminal.ErrTimeout.With("timed out waiting for auth to %s", check.pin.Hub)
+			return nil, nil, terminal.ErrTimeout.With("waiting for auth to %s", check.pin.Hub)
 		}
 
 		// Add terminal extension to the map.

--- a/crew/op_connect.go
+++ b/crew/op_connect.go
@@ -329,7 +329,7 @@ func (op *ConnectOp) connectedType() string {
 }
 
 // End ends the operation.
-func (op *ConnectOp) End(err *terminal.Error) {
+func (op *ConnectOp) End(err *terminal.Error) (errorToSend *terminal.Error) {
 	if err.IsError() {
 		reportConnectError(err)
 	}
@@ -348,6 +348,12 @@ func (op *ConnectOp) End(err *terminal.Error) {
 		atomic.LoadUint64(op.outgoingTraffic) == 0 { // Only if not data was received.
 		op.tunnel.avoidDestinationHub()
 	}
+
+	// If we are on the client, don't leak the error to the server.
+	if op.entry {
+		return terminal.ErrStopping
+	}
+	return err
 }
 
 // Abandon ends the operation.

--- a/docks/crane_init.go
+++ b/docks/crane_init.go
@@ -95,7 +95,7 @@ func (crane *Crane) startLocal() *terminal.Error {
 		select {
 		case reply = <-crane.unloading:
 		case <-time.After(5 * time.Second):
-			return terminal.ErrTimeout.With("timed out waiting for hub info")
+			return terminal.ErrTimeout.With("waiting for hub info")
 		case <-crane.ctx.Done():
 			return terminal.ErrShipSunk.With("waiting for hub info")
 		}
@@ -187,7 +187,7 @@ handling:
 		case request = <-crane.unloading:
 
 		case <-time.After(5 * time.Second):
-			return terminal.ErrTimeout.With("timed out waiting for crane init msg")
+			return terminal.ErrTimeout.With("waiting for crane init msg")
 		case <-crane.ctx.Done():
 			return terminal.ErrShipSunk.With("waiting for crane init msg")
 		}

--- a/docks/measurements.go
+++ b/docks/measurements.go
@@ -61,7 +61,7 @@ func MeasureHub(ctx context.Context, h *hub.Hub, checkExpiryWith time.Duration) 
 			return terminal.ErrCanceled
 		case <-time.After(1 * time.Minute):
 			crane.Controller.OpEnd(latOp, terminal.ErrTimeout)
-			return terminal.ErrTimeout.With("timed out waiting for latency test")
+			return terminal.ErrTimeout.With("waiting for latency test")
 		}
 	}
 
@@ -81,7 +81,7 @@ func MeasureHub(ctx context.Context, h *hub.Hub, checkExpiryWith time.Duration) 
 			return terminal.ErrCanceled
 		case <-time.After(1 * time.Minute):
 			crane.Controller.OpEnd(capOp, terminal.ErrTimeout)
-			return terminal.ErrTimeout.With("timed out waiting for capacity test")
+			return terminal.ErrTimeout.With("waiting for capacity test")
 		}
 	}
 

--- a/docks/op_capacity.go
+++ b/docks/op_capacity.go
@@ -314,11 +314,12 @@ func (op *CapacityTestOp) Deliver(c *container.Container) *terminal.Error {
 }
 
 // End ends the operation.
-func (op *CapacityTestOp) End(tErr *terminal.Error) {
+func (op *CapacityTestOp) End(tErr *terminal.Error) (errorToSend *terminal.Error) {
 	select {
 	case op.result <- tErr:
 	default:
 	}
+	return tErr
 }
 
 // Result returns the result (end error) of the operation.

--- a/docks/op_expand.go
+++ b/docks/op_expand.go
@@ -285,11 +285,11 @@ func (op *ExpandOp) backwardHandler(_ context.Context) error {
 // Abandon abandons the expansion.
 func (op *ExpandOp) Abandon(err *terminal.Error) {
 	// Proxy for Terminal Interface needed for the Duplex Flow Queue.
-	op.End(err)
+	_ = op.End(err)
 }
 
 // End abandons the expansion.
-func (op *ExpandOp) End(err *terminal.Error) {
+func (op *ExpandOp) End(err *terminal.Error) (errorToSend *terminal.Error) {
 	if op.ended.SetToIf(false, true) {
 		// Init proper process.
 		op.opTerminal.OpEnd(op, err)
@@ -300,6 +300,7 @@ func (op *ExpandOp) End(err *terminal.Error) {
 		// Abandon connected terminal.
 		op.relayTerminal.crane.AbandonTerminal(op.relayTerminal.id, nil)
 	}
+	return err
 }
 
 // Abandon abandons the expansion.
@@ -309,7 +310,7 @@ func (t *ExpansionRelayTerminal) Abandon(err *terminal.Error) {
 		t.crane.AbandonTerminal(t.id, err)
 
 		// End connected operation.
-		t.op.End(err.Wrap("relay failed with"))
+		_ = t.op.End(err.Wrap("relay failed with"))
 	}
 }
 

--- a/docks/op_latency.go
+++ b/docks/op_latency.go
@@ -278,12 +278,13 @@ func (op *LatencyTestClientOp) Deliver(c *container.Container) *terminal.Error {
 }
 
 // End ends the operation.
-func (op *LatencyTestClientOp) End(tErr *terminal.Error) {
+func (op *LatencyTestClientOp) End(tErr *terminal.Error) (errorToSend *terminal.Error) {
 	close(op.responses)
 	select {
 	case op.result <- tErr:
 	default:
 	}
+	return tErr
 }
 
 // Result returns the result (end error) of the operation.
@@ -335,4 +336,6 @@ func (op *LatencyTestOp) Deliver(c *container.Container) *terminal.Error {
 }
 
 // End ends the operation.
-func (op *LatencyTestOp) End(tErr *terminal.Error) {}
+func (op *LatencyTestOp) End(tErr *terminal.Error) (errorToSend *terminal.Error) {
+	return tErr
+}

--- a/docks/op_sync_state.go
+++ b/docks/op_sync_state.go
@@ -160,11 +160,12 @@ func (op *SyncStateOp) Deliver(c *container.Container) *terminal.Error {
 }
 
 // End ends the operation.
-func (op *SyncStateOp) End(tErr *terminal.Error) {
+func (op *SyncStateOp) End(tErr *terminal.Error) (errorToSend *terminal.Error) {
 	if op.result != nil {
 		select {
 		case op.result <- tErr:
 		default:
 		}
 	}
+	return tErr
 }

--- a/docks/terminal_expansion.go
+++ b/docks/terminal_expansion.go
@@ -103,8 +103,9 @@ func (t *ExpansionTerminal) HasEnded(end bool) bool {
 }
 
 // End ends the operation.
-func (t *ExpansionTerminal) End(err *terminal.Error) {
+func (t *ExpansionTerminal) End(err *terminal.Error) (errorToSend *terminal.Error) {
 	t.stop(err)
+	return err
 }
 
 // Abandon ends the terminal.

--- a/docks/terminal_expansion.go
+++ b/docks/terminal_expansion.go
@@ -2,7 +2,6 @@ package docks
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/tevino/abool"
@@ -118,8 +117,8 @@ func (t *ExpansionTerminal) stop(err *terminal.Error) {
 		switch {
 		case err == nil:
 			log.Debugf("spn/docks: expansion terminal %s is being abandoned", t.FmtID())
-		case errors.Is(err, terminal.ErrTimeout):
-			log.Debugf("spn/docks: expansion terminal %s %s", t.FmtID(), err)
+		case err.IsOK():
+			log.Infof("spn/docks: expansion terminal %s is being abandoned: %s", t.FmtID(), err)
 		default:
 			log.Warningf("spn/docks: expansion terminal %s: %s", t.FmtID(), err)
 		}

--- a/terminal/operation.go
+++ b/terminal/operation.go
@@ -24,7 +24,7 @@ type Operation interface {
 	Type() string
 	Deliver(data *container.Container) *Error
 	HasEnded(end bool) bool
-	End(err *Error)
+	End(err *Error) (errorToSend *Error)
 }
 
 // OpParams defines an operation.
@@ -277,7 +277,9 @@ func (op *unknownOp) Deliver(data *container.Container) *Error {
 	return ErrIncorrectUsage.With("unknown op shim cannot receive")
 }
 
-func (op *unknownOp) End(err *Error) {}
+func (op *unknownOp) End(err *Error) (errorToSend *Error) {
+	return err
+}
 
 func (op *unknownOp) HasEnded(end bool) bool {
 	if end {

--- a/terminal/operation_base.go
+++ b/terminal/operation_base.go
@@ -62,9 +62,10 @@ func (op *OpBaseRequest) Deliver(data *container.Container) *Error {
 }
 
 // End ends the operation.
-func (op *OpBaseRequest) End(err *Error) {
+func (op *OpBaseRequest) End(err *Error) (errorToSend *Error) {
 	select {
 	case op.Ended <- err:
 	default:
 	}
+	return err
 }

--- a/terminal/operation_counter.go
+++ b/terminal/operation_counter.go
@@ -200,7 +200,7 @@ func (op *CounterOp) Deliver(data *container.Container) *Error {
 }
 
 // End ends the operation.
-func (op *CounterOp) End(err *Error) {
+func (op *CounterOp) End(err *Error) (errorToSend *Error) {
 	// Check if counting finished.
 	if !op.isDone() {
 		err := fmt.Errorf(
@@ -213,6 +213,7 @@ func (op *CounterOp) End(err *Error) {
 	}
 
 	op.wg.Done()
+	return err
 }
 
 // SendCounter sends the next counter.

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -266,7 +266,7 @@ func (t *TerminalBase) Handler(_ context.Context) error {
 			// If nothing happens for a while, end the session.
 			if atomic.AddUint32(t.idleCounter, 1) > timeoutTicks {
 				// Abandon the terminal and reset the counter.
-				t.ext.Abandon(ErrTimeout.With("no activity"))
+				t.ext.Abandon(ErrNoActivity)
 				atomic.StoreUint32(t.idleCounter, 0)
 			}
 
@@ -356,7 +356,7 @@ handling:
 			// If nothing happens for a while, end the session.
 			if atomic.AddUint32(t.idleCounter, 1) > timeoutTicks {
 				// Abandon the terminal and reset the counter.
-				t.ext.Abandon(ErrTimeout.With("no activity"))
+				t.ext.Abandon(ErrNoActivity)
 				atomic.StoreUint32(t.idleCounter, 0)
 			}
 


### PR DESCRIPTION
- Remove bootstrap flag from client state
- Allow OpEnd to change the sent error message
- Lower log level for expansion terminal OK errors
- Improve error usage and wording
