### PR TITLE
Fix superseding and other improvements

### DIFF
--- a/captain/api.go
+++ b/captain/api.go
@@ -10,9 +10,13 @@ import (
 	"github.com/safing/portbase/modules"
 )
 
+const (
+	apiPathForSPNReInit = "spn/reinit"
+)
+
 func registerAPIEndpoints() error {
 	if err := api.RegisterEndpoint(api.Endpoint{
-		Path:  `spn/reinit`,
+		Path:  apiPathForSPNReInit,
 		Write: api.PermitAdmin,
 		// BelongsTo:   module, // Do not attach to module, as this must run outside of the module.
 		ActionFunc:  handleReInit,

--- a/captain/client.go
+++ b/captain/client.go
@@ -333,12 +333,28 @@ func clientConnectToHomeHub(ctx context.Context) clientComponentResult {
 			notifications.NotifyError(
 				"spn:all-home-hubs-excluded",
 				"All Home Nodes Excluded",
-				"Your current Home Node Rules exclude all available SPN Nodes. Please change your rules to allow for at least one available Home Node.",
+				"Your current Home Node Rules exclude all available and eligible SPN Nodes. Please change your rules to allow for at least one available and eligible Home Node.",
 				notifications.Action{
 					Text: "Configure",
 					Type: notifications.ActionTypeOpenSetting,
 					Payload: &notifications.ActionTypeOpenSettingPayload{
 						Key: CfgOptionHomeHubPolicyKey,
+					},
+				},
+			).AttachToModule(module)
+
+		case errors.Is(err, ErrReInitSPNSuggested):
+			notifications.NotifyError(
+				"spn:cannot-bootstrap",
+				"SPN Cannot Bootstrap",
+				"The local state of the SPN network is likely outdated. Portmaster was not able to identify a server to connect to. Please re-initialize the SPN using the tools menu or the button on the notification.",
+				notifications.Action{
+					ID:   "re-init",
+					Text: "Re-Init SPN",
+					Type: notifications.ActionTypeWebhook,
+					Payload: &notifications.ActionTypeWebhookPayload{
+						URL:          apiPathForSPNReInit,
+						ResultAction: "display",
 					},
 				},
 			).AttachToModule(module)

--- a/captain/navigation.go
+++ b/captain/navigation.go
@@ -77,7 +77,7 @@ findCandidates:
 	candidates, err := navigator.Main.FindNearestHubs(
 		locations.BestV4().LocationOrNil(),
 		locations.BestV6().LocationOrNil(),
-		opts, navigator.HomeHub, navigator.DefaultMaxFindMatches,
+		opts, navigator.HomeHub,
 	)
 	if err != nil {
 		if errors.Is(err, navigator.ErrEmptyMap) {

--- a/crew/connect.go
+++ b/crew/connect.go
@@ -152,7 +152,6 @@ func (t *Tunnel) establish(ctx context.Context) (err error) {
 		routes, err = navigator.Main.FindRouteToHub(
 			sticksTo.Pin.Hub.ID,
 			t.connInfo.TunnelOpts,
-			navigator.DefaultMaxFindMatches,
 		)
 		if err != nil {
 			log.Tracer(ctx).Tracef("spn/crew: failed to find route to stickied %s: %s", sticksTo.Pin.Hub, err)
@@ -168,7 +167,6 @@ func (t *Tunnel) establish(ctx context.Context) (err error) {
 		routes, err = navigator.Main.FindRoutes(
 			t.connInfo.Entity.IP,
 			t.connInfo.TunnelOpts,
-			navigator.DefaultMaxFindMatches,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to find routes to %s: %w", t.connInfo.Entity.IP, err)

--- a/crew/connect.go
+++ b/crew/connect.go
@@ -57,6 +57,9 @@ func (t *Tunnel) connectWorker(ctx context.Context) (err error) {
 	ctx, tracer := log.AddTracer(ctx)
 	defer tracer.Submit()
 
+	// Save start time.
+	started := time.Now()
+
 	// Check the status of the Home Hub.
 	home, homeTerminal := navigator.Main.GetHome()
 	if home == nil || homeTerminal == nil || homeTerminal.IsBeingAbandoned() {
@@ -101,6 +104,9 @@ func (t *Tunnel) connectWorker(ctx context.Context) (err error) {
 		tracer.Warningf("spn/crew: failed to initialize tunnel for %s: %s", t.connInfo, err)
 		return tErr
 	}
+
+	// Report time taken to find, build and check route and send connect request.
+	connectOpTTCRDurationHistogram.UpdateDuration(started)
 
 	t.connInfo.Lock()
 	defer t.connInfo.Unlock()

--- a/crew/metrics.go
+++ b/crew/metrics.go
@@ -14,6 +14,8 @@ var (
 	connectOpIncomingBytes *metrics.Counter
 	connectOpOutgoingBytes *metrics.Counter
 
+	connectOpTTCRDurationHistogram *metrics.Histogram
+	connectOpTTFBDurationHistogram *metrics.Histogram
 	connectOpDurationHistogram     *metrics.Histogram
 	connectOpIncomingDataHistogram *metrics.Histogram
 	connectOpOutgoingDataHistogram *metrics.Histogram
@@ -71,6 +73,30 @@ func registerMetrics() (err error) {
 		nil,
 		&metrics.Options{
 			Name:       "SPN Connect Operation Outgoing Bytes",
+			Permission: api.PermitUser,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	connectOpTTCRDurationHistogram, err = metrics.NewHistogram(
+		"spn/op/connect/histogram/ttcr/seconds",
+		nil,
+		&metrics.Options{
+			Name:       "SPN Connect Operation time-to-connect-request Histogram",
+			Permission: api.PermitUser,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	connectOpTTFBDurationHistogram, err = metrics.NewHistogram(
+		"spn/op/connect/histogram/ttfb/seconds",
+		nil,
+		&metrics.Options{
+			Name:       "SPN Connect Operation time-to-first-byte (from TTCR) Histogram",
 			Permission: api.PermitUser,
 		},
 	)

--- a/crew/op_connect.go
+++ b/crew/op_connect.go
@@ -42,6 +42,7 @@ type ConnectOp struct {
 	// Metrics
 	incomingTraffic *uint64
 	outgoingTraffic *uint64
+	started         time.Time
 
 	// Connection
 	t       terminal.Terminal
@@ -134,6 +135,7 @@ func NewConnectOp(tunnel *Tunnel) (*ConnectOp, *terminal.Error) {
 	// Setup metrics.
 	op.incomingTraffic = new(uint64)
 	op.outgoingTraffic = new(uint64)
+	op.started = time.Now()
 
 	module.StartWorker("connect op conn reader", op.connReader)
 	module.StartWorker("connect op conn writer", op.connWriter)
@@ -238,10 +240,9 @@ func (op *ConnectOp) connReader(_ context.Context) error {
 	// Metrics setup and submitting.
 	if !op.entry {
 		atomic.AddInt64(activeConnectOps, 1)
-		started := time.Now()
 		defer func() {
 			atomic.AddInt64(activeConnectOps, -1)
-			connectOpDurationHistogram.UpdateDuration(started)
+			connectOpDurationHistogram.UpdateDuration(op.started)
 			connectOpIncomingDataHistogram.Update(float64(atomic.LoadUint64(op.incomingTraffic)))
 			connectOpOutgoingDataHistogram.Update(float64(atomic.LoadUint64(op.outgoingTraffic)))
 		}()
@@ -353,11 +354,16 @@ writing:
 			rateLimiter.Limit(uint64(len(data)))
 		}
 
-		// If on client and the first data was received, sticky the destination to the Hub.
-		if op.entry && // On clients only.
-			out == uint64(len(data)) && // Only on first packet received.
-			!op.tunnel.stickied {
-			op.tunnel.stickDestinationToHub()
+		// Special handling after first data was received on client.
+		if op.entry &&
+			out == uint64(len(data)) {
+			// Report time taken to receive first byte.
+			connectOpTTFBDurationHistogram.UpdateDuration(op.started)
+
+			// If not stickied yet, stick destination to Hub.
+			if !op.tunnel.stickied {
+				op.tunnel.stickDestinationToHub()
+			}
 		}
 
 		// Send all given data.

--- a/navigator/costs.go
+++ b/navigator/costs.go
@@ -3,12 +3,13 @@ package navigator
 import "time"
 
 const (
-	nearestPinsMaxProximityDifference = 50
-	nearestPinsMinimum                = 3
+	nearestPinsMaxCostDifference = 5000
+	nearestPinsMinimum           = 10
 )
 
 // CalculateLaneCost calculates the cost of using a Lane based on the given
 // Lane latency and capacity.
+// Ranges from 0 to 10000.
 func CalculateLaneCost(latency time.Duration, capacity int) (cost float32) {
 	// - One point for every ms in latency (linear)
 	if latency != 0 {
@@ -44,6 +45,7 @@ func CalculateLaneCost(latency time.Duration, capacity int) (cost float32) {
 }
 
 // CalculateHubCost calculates the cost of using a Hub based on the given Hub load.
+// Ranges from 100 to 10000.
 func CalculateHubCost(load int) (cost float32) {
 	switch {
 	case load >= 100:
@@ -59,11 +61,12 @@ func CalculateHubCost(load int) (cost float32) {
 
 // CalculateDestinationCost calculates the cost of a destination hub to a
 // destination server based on the given proximity.
+// Ranges from 0 to 10000.
 func CalculateDestinationCost(proximity float32) (cost float32) {
 	// Invert from proximity (0-100) to get a distance value.
 	distance := 100 - proximity
 
-	// Take the distance to the power of two and then divide by ten in order to
+	// Take the distance to the power of three and then divide by hundred in order to
 	// make high distances exponentially more expensive.
-	return (distance * distance) / 10
+	return (distance * distance * distance) / 100
 }

--- a/navigator/costs.go
+++ b/navigator/costs.go
@@ -61,12 +61,12 @@ func CalculateHubCost(load int) (cost float32) {
 
 // CalculateDestinationCost calculates the cost of a destination hub to a
 // destination server based on the given proximity.
-// Ranges from 0 to 10000.
+// Ranges from 0 to 2500.
 func CalculateDestinationCost(proximity float32) (cost float32) {
 	// Invert from proximity (0-100) to get a distance value.
 	distance := 100 - proximity
 
 	// Take the distance to the power of three and then divide by hundred in order to
 	// make high distances exponentially more expensive.
-	return (distance * distance * distance) / 100
+	return (distance * distance * distance) / 400
 }

--- a/navigator/findnearest.go
+++ b/navigator/findnearest.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/safing/portmaster/intel/geoip"
 	"github.com/safing/spn/hub"
@@ -12,21 +13,21 @@ import (
 
 // DefaultMaxFindMatches defines a default value of how many matches a find
 // operation in a map should return.
-const DefaultMaxFindMatches = 20
+const DefaultMaxFindMatches = 100
 
 // nearbyPins is a list of nearby Pins to a certain location.
 type nearbyPins struct {
-	pins         []*nearbyPin
-	minPins      int
-	maxPins      int
-	minProximity float32
-	cutOffLimit  float32
+	pins        []*nearbyPin
+	minPins     int
+	maxPins     int
+	maxCost     float32
+	cutOffLimit float32
 }
 
 // nearbyPin represents a Pin and the proximity to a certain location.
 type nearbyPin struct {
-	pin       *Pin
-	proximity float32
+	pin  *Pin
+	cost float32
 }
 
 // Len is the number of elements in the collection.
@@ -37,7 +38,7 @@ func (nb *nearbyPins) Len() int {
 // Less reports whether the element with index i should sort before the element
 // with index j.
 func (nb *nearbyPins) Less(i, j int) bool {
-	return nb.pins[i].proximity > nb.pins[j].proximity
+	return nb.pins[i].cost < nb.pins[j].cost
 }
 
 // Swap swaps the elements with indexes i and j.
@@ -46,14 +47,14 @@ func (nb *nearbyPins) Swap(i, j int) {
 }
 
 // add potentially adds a Pin to the list of nearby Pins.
-func (nb *nearbyPins) add(pin *Pin, proximity float32) {
-	if len(nb.pins) > nb.minPins && proximity < nb.minProximity {
+func (nb *nearbyPins) add(pin *Pin, cost float32) {
+	if len(nb.pins) > nb.minPins && nb.maxCost > 0 && cost > nb.maxCost {
 		return
 	}
 
 	nb.pins = append(nb.pins, &nearbyPin{
-		pin:       pin,
-		proximity: proximity,
+		pin:  pin,
+		cost: cost,
 	})
 }
 
@@ -73,37 +74,27 @@ func (nb *nearbyPins) clean() {
 	// Sort nearby Pins so that the closest one is on top.
 	sort.Sort(nb)
 
-	// Set minimum proximity based on max difference, if we have enough pins.
+	// Set maximum cost based on max difference, if we have enough pins.
 	if len(nb.pins) >= nb.minPins {
-		nb.minProximity = nb.pins[0].proximity - nb.cutOffLimit
+		nb.maxCost = nb.pins[0].cost + nb.cutOffLimit
 	}
 
 	// Remove superfluous Pins from the list.
 	if len(nb.pins) > nb.maxPins {
 		nb.pins = nb.pins[:nb.maxPins]
 	}
-	// Remove Pins that are too far away.
+	// Remove Pins that are too costly.
 	if len(nb.pins) > nb.minPins {
-		// Search for first pin that is too far away.
+		// Search for first pin that is too costly.
 		okUntil := nb.minPins
 		for ; okUntil < len(nb.pins); okUntil++ {
-			if nb.pins[okUntil].proximity < nb.minProximity {
+			if nb.pins[okUntil].cost > nb.maxCost {
 				break
 			}
 		}
 		// Cut off the list at that point.
 		nb.pins = nb.pins[:okUntil]
 	}
-
-	// Raise minimum proximity to that of the last entry, if we have enough pins.
-	if len(nb.pins) >= nb.minPins && nb.pins[len(nb.pins)-1].proximity > nb.minProximity {
-		nb.minProximity = nb.pins[len(nb.pins)-1].proximity
-	}
-}
-
-// nearbyPin represents a Pin and the proximity to a certain location.
-func (nb *nearbyPin) DstCost() float32 {
-	return CalculateDestinationCost(nb.proximity)
 }
 
 // FindNearestHubs searches for the nearest Hubs to the given IP address. The returned Hubs must not be modified in any way.
@@ -122,7 +113,7 @@ func (m *Map) FindNearestHubs(locationV4, locationV6 *geoip.Location, opts *Opti
 	}
 
 	// Find nearest Pins.
-	nearby, err := m.findNearestPins(locationV4, locationV6, opts.Matcher(matchFor, m.intel), maxMatches)
+	nearby, err := m.findNearestPins(locationV4, locationV6, opts, matchFor, maxMatches)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +126,8 @@ func (m *Map) FindNearestHubs(locationV4, locationV6 *geoip.Location, opts *Opti
 	return hubs, nil
 }
 
-func (m *Map) findNearestPins(locationV4, locationV6 *geoip.Location, matcher PinMatcher, maxMatches int) (*nearbyPins, error) {
+func (m *Map) findNearestPins(locationV4, locationV6 *geoip.Location, opts *Options, matchFor HubType, maxMatches int) (*nearbyPins, error) {
+	// Fail if no location is provided.
 	if locationV4 == nil && locationV6 == nil {
 		return nil, errors.New("no location provided")
 	}
@@ -149,11 +141,16 @@ func (m *Map) findNearestPins(locationV4, locationV6 *geoip.Location, matcher Pi
 	nearby := &nearbyPins{
 		minPins:     nearestPinsMinimum,
 		maxPins:     maxMatches,
-		cutOffLimit: nearestPinsMaxProximityDifference,
+		cutOffLimit: nearestPinsMaxCostDifference,
 	}
+
+	// Create pin matcher.
+	matcher := opts.Matcher(matchFor, m.intel)
 
 	// Iterate over all Pins in the Map to find the nearest ones.
 	for _, pin := range m.all {
+		var cost float32
+
 		// Check if the Pin matches the criteria.
 		if !matcher(pin) {
 			// Debugging:
@@ -161,45 +158,93 @@ func (m *Map) findNearestPins(locationV4, locationV6 *geoip.Location, matcher Pi
 			continue
 		}
 
-		// Calculate IPv4 proximity and add Pin to the list.
+		// If finding a home hub, check if there is a common IP version.
+		if matchFor == HomeHub {
+			switch {
+			case locationV4 != nil && pin.LocationV4 != nil:
+				// Both have IPv4!
+			case locationV6 != nil && pin.LocationV6 != nil:
+				// Both have IPv6!
+			default:
+				// No shared IP stack.
+				continue
+			}
+		}
+
+		// 1. Calculate cost based on distance
+
 		if locationV4 != nil && pin.LocationV4 != nil {
-			var proximity float32
-			switch {
-			case !locationV4.IsAnycast:
-				// Regular proximity calculation.
-				proximity = pin.LocationV4.EstimateNetworkProximity(locationV4)
-			case m.home != nil:
-				// If the destination is anycast, calculate distance to home hub instead, if possible.
-				proximity = proximityBetweenPins(pin, m.home)
+			if locationV4.IsAnycast && m.home != nil {
+				// If the destination is anycast, calculate cost though proximity to home hub instead, if possible.
+				cost = lessButPositive(cost, CalculateDestinationCost(
+					proximityBetweenPins(pin, m.home),
+				))
+			} else {
+				// Regular cost calculation through proximity.
+				cost = lessButPositive(cost, CalculateDestinationCost(
+					locationV4.EstimateNetworkProximity(pin.LocationV4),
+				))
 			}
-
-			// If no proximity could be calculated, fall back to a default value.
-			if proximity == 0 {
-				proximity = 50 // out of 0-100
-			}
-
-			nearby.add(pin, proximity)
 		}
 
-		// Calculate IPv6 proximity and add Pin to the list.
 		if locationV6 != nil && pin.LocationV6 != nil {
-			var proximity float32
-			switch {
-			case !locationV6.IsAnycast:
-				// Regular proximity calculation.
-				proximity = pin.LocationV6.EstimateNetworkProximity(locationV6)
-			case m.home != nil:
-				// If the destination is anycast, calculate distance to home hub instead, if possible.
-				proximity = proximityBetweenPins(pin, m.home)
+			if locationV6.IsAnycast && m.home != nil {
+				// If the destination is anycast, calculate cost though proximity to home hub instead, if possible.
+				cost = lessButPositive(cost, CalculateDestinationCost(
+					proximityBetweenPins(pin, m.home),
+				))
+			} else {
+				// Regular cost calculation through proximity.
+				cost = lessButPositive(cost, CalculateDestinationCost(
+					locationV6.EstimateNetworkProximity(pin.LocationV6),
+				))
 			}
-
-			// If no proximity could be calculated, fall back to a default value.
-			if proximity == 0 {
-				proximity = 50 // out of 0-100
-			}
-
-			nearby.add(pin, proximity)
 		}
+
+		// If no cost could be calculated, fall back to a default value.
+		if cost == 0 {
+			cost = CalculateDestinationCost(50) // proximity out of 0-100
+		}
+
+		// Debugging:
+		// if matchFor == HomeHub {
+		// 	log.Tracef("spn/navigator: adding %.2f proximity cost to home hub %s", cost, pin.Hub)
+		// }
+
+		// 2. Add cost based on Hub status
+
+		cost += CalculateHubCost(pin.Hub.Status.Load)
+
+		// Debugging:
+		// if matchFor == HomeHub {
+		// 	log.Tracef("spn/navigator: adding %.2f hub cost to home hub %s", CalculateHubCost(pin.Hub.Status.Load), pin.Hub)
+		// }
+
+		// 3. If matching a home hub, add cost based on capacity/latency performance.
+
+		if matchFor == HomeHub {
+			// Find best capacity/latency values.
+			var (
+				bestCapacity int
+				bestLatency  time.Duration
+			)
+			for _, lane := range pin.Hub.Status.Lanes {
+				if lane.Capacity > bestCapacity {
+					bestCapacity = lane.Capacity
+				}
+				if bestLatency == 0 || lane.Latency < bestLatency {
+					bestLatency = lane.Latency
+				}
+			}
+			// Add cost of best capacity/latency values.
+			cost += CalculateLaneCost(bestLatency, bestCapacity)
+
+			// Debugging:
+			// log.Tracef("spn/navigator: adding %.2f lane cost to home hub %s", CalculateLaneCost(bestLatency, bestCapacity), pin.Hub)
+			// log.Debugf("spn/navigator: total cost of %.2f to home hub %s", cost, pin.Hub)
+		}
+
+		nearby.add(pin, cost)
 
 		// Clean the nearby list if have collected more than two times the max amount.
 		if len(nearby.pins) >= nearby.maxPins*2 {
@@ -214,6 +259,15 @@ func (m *Map) findNearestPins(locationV4, locationV6 *geoip.Location, matcher Pi
 
 	// Clean one last time and return the list.
 	nearby.clean()
+
+	// Debugging:
+	// if matchFor == HomeHub {
+	// 	log.Debug("spn/navigator: nearby pins:")
+	// 	for _, nbPin := range nearby.pins {
+	// 		log.Debugf("spn/navigator: nearby pin %s", nbPin)
+	// 	}
+	// }
+
 	return nearby, nil
 }
 
@@ -226,7 +280,7 @@ func (nb *nearbyPins) String() string {
 }
 
 func (nb *nearbyPin) String() string {
-	return fmt.Sprintf("%s at %.2f prox", nb.pin, nb.proximity)
+	return fmt.Sprintf("%s at %.2fc", nb.pin, nb.cost)
 }
 
 func proximityBetweenPins(a, b *Pin) float32 {
@@ -247,4 +301,17 @@ func proximityBetweenPins(a, b *Pin) float32 {
 		return x
 	}
 	return y
+}
+
+func lessButPositive(a, b float32) float32 {
+	switch {
+	case a == 0:
+		return b
+	case b == 0:
+		return a
+	case a < b:
+		return a
+	default:
+		return b
+	}
 }

--- a/navigator/findnearest_test.go
+++ b/navigator/findnearest_test.go
@@ -16,7 +16,7 @@ func TestFindNearest(t *testing.T) {
 		// Create a random destination address
 		ip4, loc4 := createGoodIP(true)
 
-		nbPins, err := m.findNearestPins(loc4, nil, m.DefaultOptions(), DestinationHub, DefaultMaxFindMatches)
+		nbPins, err := m.findNearestPins(loc4, nil, m.DefaultOptions(), DestinationHub)
 		if err != nil {
 			t.Error(err)
 		} else {
@@ -28,7 +28,7 @@ func TestFindNearest(t *testing.T) {
 		// Create a random destination address
 		ip6, loc6 := createGoodIP(true)
 
-		nbPins, err := m.findNearestPins(nil, loc6, m.DefaultOptions(), DestinationHub, DefaultMaxFindMatches)
+		nbPins, err := m.findNearestPins(nil, loc6, m.DefaultOptions(), DestinationHub)
 		if err != nil {
 			t.Error(err)
 		} else {
@@ -68,7 +68,7 @@ func findFakeHomeHub(m *Map) {
 	_, loc4 := createGoodIP(true)
 	_, loc6 := createGoodIP(false)
 
-	nbPins, err := m.findNearestPins(loc4, loc6, m.defaultOptions(), HomeHub, DefaultMaxFindMatches)
+	nbPins, err := m.findNearestPins(loc4, loc6, m.defaultOptions(), HomeHub)
 	if err != nil {
 		panic(err)
 	}

--- a/navigator/findnearest_test.go
+++ b/navigator/findnearest_test.go
@@ -88,25 +88,25 @@ func findFakeHomeHub(m *Map) {
 func TestNearbyPinsCleaning(t *testing.T) {
 	t.Parallel()
 
-	testCleaning(t, []float32{10, 20, 30, 40, 50, 60, 70, 80, 90, 100}, 5)
-	testCleaning(t, []float32{10, 11, 12, 13, 14, 15, 70, 80, 90, 100}, 4)
-	testCleaning(t, []float32{10, 11, 12, 13, 14, 15, 16, 80, 90, 100}, 3)
-	testCleaning(t, []float32{10, 11, 12, 13, 14, 15, 16, 17, 90, 100}, 3)
+	testCleaning(t, []float32{10, 20, 30, 40, 50, 60, 70, 80, 90, 100}, 3)
+	testCleaning(t, []float32{10, 11, 12, 13, 50, 60, 70, 80, 90, 100}, 4)
+	testCleaning(t, []float32{10, 11, 12, 40, 50, 60, 70, 80, 90, 100}, 3)
+	testCleaning(t, []float32{10, 11, 30, 40, 50, 60, 70, 80, 90, 100}, 3)
 }
 
-func testCleaning(t *testing.T, proximities []float32, expectedLeftOver int) {
+func testCleaning(t *testing.T, costs []float32, expectedLeftOver int) {
 	t.Helper()
 
 	nb := &nearbyPins{
 		minPins:     3,
 		maxPins:     5,
-		cutOffLimit: 50,
+		cutOffLimit: 10,
 	}
 
 	// Simulate usage.
-	for _, prox := range proximities {
+	for _, cost := range costs {
 		// Add to list.
-		nb.add(nil, prox)
+		nb.add(nil, cost)
 
 		// Clean once in a while.
 		if len(nb.pins) > nb.maxPins {
@@ -119,6 +119,6 @@ func testCleaning(t *testing.T, proximities []float32, expectedLeftOver int) {
 	// Check results.
 	t.Logf("result: %+v", nb.pins)
 	if len(nb.pins) != expectedLeftOver {
-		t.Fatalf("unexpected amount of left over pins: %+v", nb.pins)
+		t.Errorf("unexpected amount of left over pins: %+v", nb.pins)
 	}
 }

--- a/navigator/findnearest_test.go
+++ b/navigator/findnearest_test.go
@@ -16,7 +16,7 @@ func TestFindNearest(t *testing.T) {
 		// Create a random destination address
 		ip4, loc4 := createGoodIP(true)
 
-		nbPins, err := m.findNearestPins(loc4, nil, m.DefaultOptions().Matcher(DestinationHub, m.intel), DefaultMaxFindMatches)
+		nbPins, err := m.findNearestPins(loc4, nil, m.DefaultOptions(), DestinationHub, DefaultMaxFindMatches)
 		if err != nil {
 			t.Error(err)
 		} else {
@@ -28,7 +28,7 @@ func TestFindNearest(t *testing.T) {
 		// Create a random destination address
 		ip6, loc6 := createGoodIP(true)
 
-		nbPins, err := m.findNearestPins(nil, loc6, m.DefaultOptions().Matcher(DestinationHub, m.intel), DefaultMaxFindMatches)
+		nbPins, err := m.findNearestPins(nil, loc6, m.DefaultOptions(), DestinationHub, DefaultMaxFindMatches)
 		if err != nil {
 			t.Error(err)
 		} else {
@@ -56,8 +56,7 @@ func BenchmarkFindNearest(b *testing.B) {
 			dstIP = net.ParseIP(gofakeit.IPv6Address())
 		}
 
-		_, err := m.findNearestPins(dstIP, m.DefaultOptions().Matcher(DestinationHub), defaultMaxFindMatches)
-		if err != nil {
+		_, err := m.findNearestPins(dstIP, m.DefaultOptions(),DestinationHub		if err != nil {
 			b.Error(err)
 		}
 	}
@@ -69,7 +68,7 @@ func findFakeHomeHub(m *Map) {
 	_, loc4 := createGoodIP(true)
 	_, loc6 := createGoodIP(false)
 
-	nbPins, err := m.findNearestPins(loc4, loc6, m.defaultOptions().Matcher(HomeHub, m.intel), DefaultMaxFindMatches)
+	nbPins, err := m.findNearestPins(loc4, loc6, m.defaultOptions(), HomeHub, DefaultMaxFindMatches)
 	if err != nil {
 		panic(err)
 	}

--- a/navigator/findroutes.go
+++ b/navigator/findroutes.go
@@ -159,7 +159,7 @@ func (m *Map) findRoutes(dsts *nearbyPins, opts *Options, maxRoutes int) (*Route
 				if nbPin != nil {
 					// Pin is listed as selected Destination Hub!
 					// Complete route to add destination ("last mile") cost.
-					route.completeRoute(nbPin.DstCost())
+					route.completeRoute(nbPin.cost)
 					routes.add(route)
 
 					// We have found a route and have come to an end here.

--- a/navigator/findroutes_test.go
+++ b/navigator/findroutes_test.go
@@ -17,7 +17,7 @@ func TestFindRoutes(t *testing.T) {
 		// Create a random destination address
 		dstIP, _ := createGoodIP(i%2 == 0)
 
-		routes, err := m.FindRoutes(dstIP, m.DefaultOptions(), 10)
+		routes, err := m.FindRoutes(dstIP, m.DefaultOptions())
 		switch {
 		case err != nil:
 			t.Error(err)
@@ -44,7 +44,7 @@ func BenchmarkFindRoutes(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		routes, err := m.FindRoutes(preGenIPs[i%len(preGenIPs)], m.DefaultOptions(), 10)
+		routes, err := m.FindRoutes(preGenIPs[i%len(preGenIPs)], m.DefaultOptions())
 		if err != nil {
 			b.Error(err)
 		} else {

--- a/navigator/module.go
+++ b/navigator/module.go
@@ -10,6 +10,11 @@ import (
 	"github.com/safing/spn/conf"
 )
 
+const (
+	// cfgOptionRoutingAlgorithmKey is copied from profile/config.go to avoid import loop.
+	cfgOptionRoutingAlgorithmKey = "spn/routingAlgorithm"
+)
+
 var (
 	// ErrHomeHubUnset is returned when the Home Hub is required and not set.
 	ErrHomeHubUnset = errors.New("map has no Home Hub set")
@@ -19,6 +24,9 @@ var (
 
 	// ErrHubNotFound is returned when the Hub was not found on the Map.
 	ErrHubNotFound = errors.New("hub not found")
+
+	// ErrAllPinsDisregarded is returned when all pins have been disregarded.
+	ErrAllPinsDisregarded = errors.New("all pins have been disregarded")
 )
 
 var (
@@ -27,7 +35,8 @@ var (
 	// Main is the primary map used.
 	Main *Map
 
-	devMode config.BoolOption
+	devMode                   config.BoolOption
+	cfgOptionRoutingAlgorithm config.StringOption
 )
 
 func init() {
@@ -41,6 +50,7 @@ func prep() error {
 func start() error {
 	Main = NewMap(conf.MainMapName, true)
 	devMode = config.Concurrent.GetAsBool(config.CfgDevModeKey, false)
+	cfgOptionRoutingAlgorithm = config.Concurrent.GetAsString(cfgOptionRoutingAlgorithmKey, DefaultRoutingProfileID)
 
 	err := registerMapDatabase()
 	if err != nil {

--- a/navigator/update.go
+++ b/navigator/update.go
@@ -249,7 +249,6 @@ func (m *Map) updateHub(h *hub.Hub, lockMap, lockHub bool) {
 	m.updateIntelStatuses(pin)
 
 	// Update Statuses derived from Hub.
-	m.updateStateSuperseded(pin)
 	pin.updateStateHasRequiredInfo()
 	pin.updateStateActive(time.Now().Unix())
 
@@ -301,6 +300,11 @@ func (m *Map) updateHub(h *hub.Hub, lockMap, lockHub bool) {
 			log.Warningf("spn/navigator: failed to recalculate reachable Hubs: %s", err)
 		}
 	}
+
+	// 4. Update states that depend on other information.
+
+	// Check if hub is superseded or if it supersedes another hub.
+	m.updateStateSuperseded(pin)
 
 	// Push updates.
 	m.PushPinChanges()


### PR DESCRIPTION
- Fix hub comparison for superseding
- Use new ping op for pinging Home Hub
- Switch to cost-based calculation for finding nearest pins, include more cost data
- Randomize top nearby pins and routes for load balancing
- Lower destination cost for better balance in routing
- Improve home hub errors and home hub routing handling
- Add connect op TTCR and TTFB metrics
