### PR TITLE
Fix scheduler skew and improve routing

### DIFF
--- a/captain/client.go
+++ b/captain/client.go
@@ -435,6 +435,14 @@ func clientCheckHomeHubConnection(ctx context.Context) clientComponentResult {
 	latency, tErr := pingHome(ctx, crane.Controller, clientHealthCheckTimeout)
 	if tErr != nil {
 		log.Warningf("spn/captain: failed to ping home hub: %s", tErr)
+
+		// Prepare to reconnect to the network.
+
+		// Reset all failing states, as these might have been caused by the failing home hub.
+		navigator.Main.ResetFailingStates(ctx)
+		// Mark the home hub itself as failing, as we want to try to connect to somewhere else.
+		home.MarkAsFailingFor(5 * time.Minute)
+
 		return clientResultReconnect
 	}
 

--- a/crew/connect.go
+++ b/crew/connect.go
@@ -225,6 +225,13 @@ func establishRoute(route *navigator.Route) (dstPin *navigator.Pin, dstTerminal 
 		return nil, nil, errors.New("path too short")
 	}
 
+	// Check for failing hubs in path.
+	for _, hop := range route.Path[1:] {
+		if hop.Pin().GetState().Has(navigator.StateFailing) {
+			return nil, nil, fmt.Errorf("failing hub in path: %s", hop.Pin().Hub.Name())
+		}
+	}
+
 	// Get home hub.
 	previousHop, homeTerminal := navigator.Main.GetHome()
 	if previousHop == nil || homeTerminal == nil {

--- a/crew/connect.go
+++ b/crew/connect.go
@@ -315,7 +315,7 @@ func establishRoute(route *navigator.Route) (dstPin *navigator.Pin, dstTerminal 
 					return nil, nil, tErr.Wrap("failed to authenticate to %s: %w", check.pin.Hub, tErr)
 				}
 
-			case <-time.After(15 * time.Second):
+			case <-time.After(5 * time.Second):
 				// Mark as failing for just a minute, until server load may be less.
 				check.pin.MarkAsFailingFor(1 * time.Minute)
 				log.Warningf("spn/crew: auth to %s timed out", check.pin.Hub)
@@ -340,14 +340,18 @@ func establishRoute(route *navigator.Route) (dstPin *navigator.Pin, dstTerminal 
 					// TODO: Should we forcibly disconnect instead?
 					// TODO: This might also be triggered if a relay fails and ends the operation.
 					check.pin.MarkAsFailingFor(7 * time.Minute)
+					// Forget about existing active terminal, re-create if needed.
+					check.pin.SetActiveTerminal(nil)
 					log.Warningf("spn/crew: failed to check reachability of %s: %s", check.pin.Hub, tErr)
 
 					return nil, nil, tErr.Wrap("failed to check reachability of %s: %w", check.pin.Hub, tErr)
 				}
 
-			case <-time.After(15 * time.Second):
+			case <-time.After(5 * time.Second):
 				// Mark as failing for just a minute, until server load may be less.
 				check.pin.MarkAsFailingFor(1 * time.Minute)
+				// Forget about existing active terminal, re-create if needed.
+				check.pin.SetActiveTerminal(nil)
 				log.Warningf("spn/crew: reachability check to %s timed out", check.pin.Hub)
 
 				return nil, nil, terminal.ErrTimeout.With("waiting for ping to %s", check.pin.Hub)

--- a/navigator/api.go
+++ b/navigator/api.go
@@ -141,6 +141,11 @@ func registerAPIEndpoints() error {
 		return err
 	}
 
+	// Register API endpoints from other files.
+	if err := registerRouteAPIEndpoints(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/navigator/api_route.go
+++ b/navigator/api_route.go
@@ -1,0 +1,267 @@
+package navigator
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	mrand "math/rand"
+	"net"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/safing/portbase/api"
+	"github.com/safing/portmaster/intel/geoip"
+	"github.com/safing/portmaster/netenv"
+	"github.com/safing/portmaster/network/netutils"
+)
+
+func registerRouteAPIEndpoints() error {
+	if err := api.RegisterEndpoint(api.Endpoint{
+		Path:        `spn/map/{map:[A-Za-z0-9]{1,255}}/route/to/{destination:[a-z0-9_\.:-]{1,255}}`,
+		Read:        api.PermitUser,
+		BelongsTo:   module,
+		ActionFunc:  handleRouteCalculationRequest,
+		Name:        "Calculate Route through SPN",
+		Description: "Returns a textual representation of the routing process.",
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func handleRouteCalculationRequest(ar *api.Request) (msg string, err error) {
+	// Get map.
+	m, ok := getMapForAPI(ar.URLVars["map"])
+	if !ok {
+		return "", errors.New("map not found")
+	}
+
+	var introText string
+
+	// Parse destination.
+	var locationV4, locationV6 *geoip.Location
+	var dstIP net.IP
+	destination := ar.URLVars["destination"]
+	matchFor := DestinationHub
+	opts := m.defaultOptions()
+	switch {
+	case destination == "":
+		// Destination is required.
+		return "", errors.New("no destination provided")
+
+	case destination == "home":
+		// Simulate finding home hub.
+		locations, ok := netenv.GetInternetLocation()
+		if !ok || len(locations.All) == 0 {
+			return "", errors.New("failed to locate own device for finding home hub")
+		}
+		introText = fmt.Sprintf("looking for home hub near %s and %s", locations.BestV4(), locations.BestV6())
+		locationV4 = locations.BestV4().LocationOrNil()
+		locationV6 = locations.BestV6().LocationOrNil()
+		matchFor = HomeHub
+
+	case net.ParseIP(destination) != nil:
+		dstIP = net.ParseIP(destination)
+		if ip4 := dstIP.To4(); ip4 != nil {
+			locationV4, err = geoip.GetLocation(dstIP)
+			if err != nil {
+				return "", fmt.Errorf("failed to get geoip location for %s: %w", dstIP, err)
+			}
+			introText = fmt.Sprintf("looking for route to %s at %s", dstIP, formatLocation(locationV4))
+		} else {
+			locationV6, err = geoip.GetLocation(dstIP)
+			if err != nil {
+				return "", fmt.Errorf("failed to get geoip location for %s: %w", dstIP, err)
+			}
+			introText = fmt.Sprintf("looking for route to %s at %s", dstIP, formatLocation(locationV6))
+		}
+
+	case netutils.IsValidFqdn(destination):
+		fallthrough
+	case netutils.IsValidFqdn(destination + "."):
+
+		// Resolve name to IPs.
+		ips, err := net.DefaultResolver.LookupIP(ar.Context(), "ip", destination)
+		if err != nil {
+			return "", fmt.Errorf("failed to lookup IP address of %s: %w", destination, err)
+		}
+
+		// Shuffle IPs.
+		if len(ips) >= 2 {
+			r := mrand.New(mrand.NewSource(time.Now().UnixNano()))
+			r.Shuffle(len(ips), func(i, j int) {
+				ips[i], ips[j] = ips[j], ips[i]
+			})
+		}
+
+		// Get IP location.
+		dstIP = ips[0]
+		if ip4 := dstIP.To4(); ip4 != nil {
+			locationV4, err = geoip.GetLocation(dstIP)
+			if err != nil {
+				return "", fmt.Errorf("failed to get geoip location for %s: %w", dstIP, err)
+			}
+			introText = fmt.Sprintf("looking for route to %s at %s\n(ignoring %d additional IPs returned by DNS)", dstIP, formatLocation(locationV4), len(ips)-1)
+		} else {
+			locationV6, err = geoip.GetLocation(dstIP)
+			if err != nil {
+				return "", fmt.Errorf("failed to get geoip location for %s: %w", dstIP, err)
+			}
+			introText = fmt.Sprintf("looking for route to %s at %s\n(ignoring %d additional IPs returned by DNS)", dstIP, formatLocation(locationV6), len(ips)-1)
+		}
+
+	default:
+		return "", errors.New("invalid destination provided")
+	}
+
+	// Start formatting output.
+	lines := []string{
+		"Routing simulation: " + introText,
+		"Please not that this routing simulation does match the behavior of regular routing to 100%.",
+		"",
+	}
+
+	// Print options.
+	// ==================
+
+	lines = append(lines, "Routing Options:")
+	lines = append(lines, "Algorithm: "+opts.RoutingProfile)
+	lines = append(lines, fmt.Sprintf("Require Verified Owners: %s", opts.RequireVerifiedOwners))
+	lines = append(lines, fmt.Sprintf("Require Trusted Exit: %v", opts.RequireTrustedDestinationHubs))
+	lines = append(lines, "Hub Policy: ")
+	for _, ep := range opts.HubPolicies {
+		lines = append(lines, ep.String())
+	}
+	lines = append(lines, "")
+
+	// Find nearest hubs.
+	// ==================
+
+	// Start operating in map.
+	m.RLock()
+	defer m.RUnlock()
+	// Check if map is populated.
+	if m.isEmpty() {
+		return "", ErrEmptyMap
+	}
+
+	// Find nearest hubs.
+	nbPins, err := m.findNearestPins(locationV4, locationV6, opts, matchFor, true)
+	if err != nil {
+		return "", fmt.Errorf("failed to search for nearby pins: %w", err)
+	}
+
+	// Print found exits to table.
+	lines = append(lines, "Considered Exits (cheapest 10% are shuffled)")
+	buf := bytes.NewBuffer(nil)
+	tabWriter := tabwriter.NewWriter(buf, 8, 4, 3, ' ', 0)
+	fmt.Fprint(tabWriter, "Hub Name\tCost\tLocation\n")
+	for _, nbPin := range nbPins.pins {
+		fmt.Fprintf(tabWriter,
+			"%s\t%.0f\t%s\n",
+			nbPin.pin.Hub.Name(),
+			nbPin.cost,
+			formatMultiLocation(nbPin.pin.LocationV4, nbPin.pin.LocationV6),
+		)
+	}
+	_ = tabWriter.Flush()
+	lines = append(lines, buf.String())
+
+	// Print too expensive exits to table.
+	lines = append(lines, "Too Expensive Exits:")
+	buf = bytes.NewBuffer(nil)
+	tabWriter = tabwriter.NewWriter(buf, 8, 4, 3, ' ', 0)
+	fmt.Fprint(tabWriter, "Hub Name\tCost\tLocation\n")
+	for _, nbPin := range nbPins.debug.tooExpensive {
+		fmt.Fprintf(tabWriter,
+			"%s\t%.0f\t%s\n",
+			nbPin.pin.Hub.Name(),
+			nbPin.cost,
+			formatMultiLocation(nbPin.pin.LocationV4, nbPin.pin.LocationV6),
+		)
+	}
+	_ = tabWriter.Flush()
+	lines = append(lines, buf.String())
+
+	// Print disregarded exits to table.
+	lines = append(lines, "Disregarded Exits:")
+	buf = bytes.NewBuffer(nil)
+	tabWriter = tabwriter.NewWriter(buf, 8, 4, 3, ' ', 0)
+	fmt.Fprint(tabWriter, "Hub Name\tReason\tStates\n")
+	for _, nbPin := range nbPins.debug.disregarded {
+		fmt.Fprintf(tabWriter,
+			"%s\t%s\t%s\n",
+			nbPin.pin.Hub.Name(),
+			nbPin.reason,
+			nbPin.pin.State,
+		)
+	}
+	_ = tabWriter.Flush()
+	lines = append(lines, buf.String())
+
+	// Find routes.
+	// ============
+
+	// Unless we looked for a home node.
+	if destination == "home" {
+		return strings.Join(lines, "\n"), nil
+	}
+
+	// Find routes.
+	routes, err := m.findRoutes(nbPins, opts)
+	if err != nil {
+		return "", fmt.Errorf("failed to find routes: %w", err)
+	}
+
+	// Print found routes to table.
+	lines = append(lines, "Considered Routes (cheapest 10% are shuffled)")
+	buf = bytes.NewBuffer(nil)
+	tabWriter = tabwriter.NewWriter(buf, 8, 4, 3, ' ', 0)
+	fmt.Fprint(tabWriter, "Cost\tPath\n")
+	for _, route := range routes.All {
+		fmt.Fprintf(tabWriter,
+			"%.0f\t%s\n",
+			route.TotalCost,
+			formatRoute(route, dstIP),
+		)
+	}
+	_ = tabWriter.Flush()
+	lines = append(lines, buf.String())
+
+	return strings.Join(lines, "\n"), nil
+}
+
+func formatLocation(loc *geoip.Location) string {
+	return fmt.Sprintf(
+		"%s (AS%d %s)",
+		loc.Country.ISOCode,
+		loc.AutonomousSystemNumber,
+		loc.AutonomousSystemOrganization,
+	)
+}
+
+func formatMultiLocation(a, b *geoip.Location) string {
+	switch {
+	case a != nil:
+		return formatLocation(a)
+	case b != nil:
+		return formatLocation(b)
+	default:
+		return ""
+	}
+}
+
+func formatRoute(r *Route, dst net.IP) string {
+	s := make([]string, 0, len(r.Path)+1)
+	for i, hop := range r.Path {
+		if i == 0 {
+			s = append(s, hop.pin.Hub.Name())
+		} else {
+			s = append(s, fmt.Sprintf(">> %.2fc >> %s", hop.Cost, hop.pin.Hub.Name()))
+		}
+	}
+	s = append(s, fmt.Sprintf(">> %.2fc >> %s", r.DstCost, dst))
+	return strings.Join(s, " ")
+}

--- a/navigator/costs.go
+++ b/navigator/costs.go
@@ -68,5 +68,5 @@ func CalculateDestinationCost(proximity float32) (cost float32) {
 
 	// Take the distance to the power of three and then divide by hundred in order to
 	// make high distances exponentially more expensive.
-	return (distance * distance * distance) / 400
+	return (distance * distance * distance) / 100
 }

--- a/navigator/findnearest.go
+++ b/navigator/findnearest.go
@@ -198,30 +198,28 @@ func (m *Map) findNearestPins(locationV4, locationV6 *geoip.Location, opts *Opti
 			continue
 		}
 
-		// If finding a home hub, check if there is a common IP version.
-		if matchFor == HomeHub {
-			switch {
-			case locationV4 != nil && pin.LocationV4 != nil:
-				// Both have IPv4!
-			case locationV6 != nil && pin.LocationV6 != nil:
-				// Both have IPv6!
-			default:
-				// No shared IP stack.
-				continue
-			}
+		// Check if the Hub supports at least one IP version we are looking for.
+		switch {
+		case locationV4 != nil && pin.LocationV4 != nil:
+			// Both have IPv4!
+		case locationV6 != nil && pin.LocationV6 != nil:
+			// Both have IPv6!
+		default:
+			// Hub does not support any IP version we need.
+			continue
+		}
 
-			// If the global routing profile is set to home ("VPN"), check if all local
-			// IP versions are available on the Hub.
-			if cfgOptionRoutingAlgorithm() == RoutingProfileHomeID {
-				switch {
-				case locationV4 != nil && pin.LocationV4 == nil:
-					// Device has IPv4, but Hub does not!
-					continue
-				case locationV6 != nil && pin.LocationV6 == nil:
-					// Device has IPv6, but Hub does not!
-					// Both have IPv6!
-					continue
-				}
+		// If finding a home hub and the global routing profile is set to home ("VPN"),
+		// check if all local IP versions are available on the Hub.
+		if matchFor == HomeHub && cfgOptionRoutingAlgorithm() == RoutingProfileHomeID {
+			switch {
+			case locationV4 != nil && pin.LocationV4 == nil:
+				// Device has IPv4, but Hub does not!
+				continue
+			case locationV6 != nil && pin.LocationV6 == nil:
+				// Device has IPv6, but Hub does not!
+				// Both have IPv6!
+				continue
 			}
 		}
 

--- a/navigator/findnearest_test.go
+++ b/navigator/findnearest_test.go
@@ -16,7 +16,7 @@ func TestFindNearest(t *testing.T) {
 		// Create a random destination address
 		ip4, loc4 := createGoodIP(true)
 
-		nbPins, err := m.findNearestPins(loc4, nil, m.DefaultOptions(), DestinationHub)
+		nbPins, err := m.findNearestPins(loc4, nil, m.DefaultOptions(), DestinationHub, false)
 		if err != nil {
 			t.Error(err)
 		} else {
@@ -28,7 +28,7 @@ func TestFindNearest(t *testing.T) {
 		// Create a random destination address
 		ip6, loc6 := createGoodIP(true)
 
-		nbPins, err := m.findNearestPins(nil, loc6, m.DefaultOptions(), DestinationHub)
+		nbPins, err := m.findNearestPins(nil, loc6, m.DefaultOptions(), DestinationHub, false)
 		if err != nil {
 			t.Error(err)
 		} else {
@@ -68,7 +68,7 @@ func findFakeHomeHub(m *Map) {
 	_, loc4 := createGoodIP(true)
 	_, loc6 := createGoodIP(false)
 
-	nbPins, err := m.findNearestPins(loc4, loc6, m.defaultOptions(), HomeHub)
+	nbPins, err := m.findNearestPins(loc4, loc6, m.defaultOptions(), HomeHub, false)
 	if err != nil {
 		panic(err)
 	}

--- a/navigator/findroutes.go
+++ b/navigator/findroutes.go
@@ -80,7 +80,7 @@ func (m *Map) FindRoutes(ip net.IP, opts *Options) (*Routes, error) {
 	}
 
 	// Find nearest Pins.
-	nearby, err := m.findNearestPins(locationV4, locationV6, opts, DestinationHub)
+	nearby, err := m.findNearestPins(locationV4, locationV6, opts, DestinationHub, false)
 	if err != nil {
 		return nil, err
 	}

--- a/navigator/module.go
+++ b/navigator/module.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/safing/portbase/config"
+	"github.com/safing/portbase/log"
 	"github.com/safing/portbase/modules"
 	"github.com/safing/portmaster/intel/geoip"
 	"github.com/safing/spn/conf"
@@ -71,7 +72,16 @@ geoInitCheck:
 		}
 	}
 
-	Main.InitializeFromDatabase()
+	err = Main.InitializeFromDatabase()
+	if err != nil {
+		// Wait for three seconds, then try again.
+		time.Sleep(3 * time.Second)
+		err = Main.InitializeFromDatabase()
+		if err != nil {
+			// Even if the init fails, we can try to start without it and get data along the way.
+			log.Warningf("spn/navigator: %s", err)
+		}
+	}
 	err = Main.RegisterHubUpdateHook()
 	if err != nil {
 		return err

--- a/navigator/options.go
+++ b/navigator/options.go
@@ -31,7 +31,7 @@ type Options struct { //nolint:maligned
 	// set, a basic set of undesirable states is added automatically.
 	Disregard PinState
 
-	// HubPolicies is a collecion of endpoint lists that Hubs must pass in order
+	// HubPolicies is a collection of endpoint lists that Hubs must pass in order
 	// to be taken into account for the operation.
 	HubPolicies []endpoints.Endpoints
 
@@ -118,11 +118,16 @@ func (o *Options) Matcher(hubType HubType, hubIntel *hub.Intel) PinMatcher {
 			// Home Hubs don't need to be reachable and don't need keys ready to be used.
 			regard = regard.Remove(StateReachable)
 			regard = regard.Remove(StateActive)
+			// Follow advisory.
 			disregard = disregard.Add(StateUsageAsHomeDiscouraged)
+			// Home Hub may be the current Home Hub.
+			disregard = disregard.Remove(StateIsHomeHub)
 		case TransitHub:
 			// Transit Hubs get no additional states.
 		case DestinationHub:
+			// Follow advisory.
 			disregard = disregard.Add(StateUsageAsDestinationDiscouraged)
+			// Do not use if Hub reports network issues.
 			disregard = disregard.Add(StateConnectivityIssues)
 		}
 	}

--- a/navigator/update.go
+++ b/navigator/update.go
@@ -397,6 +397,18 @@ func (m *Map) updateHubLane(pin *Pin, lane *hub.Lane, peer *Pin) {
 	}
 }
 
+// ResetFailingStates resets the failing state on all pins.
+func (m *Map) ResetFailingStates(ctx context.Context) {
+	m.Lock()
+	defer m.Unlock()
+
+	for _, pin := range m.all {
+		pin.ResetFailingState()
+	}
+
+	m.PushPinChanges()
+}
+
 func (m *Map) updateFailingStates(ctx context.Context, task *modules.Task) error {
 	m.Lock()
 	defer m.Unlock()

--- a/navigator/update.go
+++ b/navigator/update.go
@@ -25,15 +25,14 @@ var db = database.NewInterface(&database.Options{
 })
 
 // InitializeFromDatabase loads all Hubs from the given database prefix and adds them to the Map.
-func (m *Map) InitializeFromDatabase() {
+func (m *Map) InitializeFromDatabase() error {
 	m.Lock()
 	defer m.Unlock()
 
 	// start query for Hubs
 	iter, err := db.Query(query.New(hub.MakeHubDBKey(m.Name, "")))
 	if err != nil {
-		log.Warningf("spn/navigator: failed to start query for initialization feed of %s map: %s", m.Name, err)
-		return
+		return fmt.Errorf("failed to start query for initialization feed of %s map: %w", m.Name, err)
 	}
 
 	// update navigator
@@ -51,12 +50,13 @@ func (m *Map) InitializeFromDatabase() {
 	}
 	switch {
 	case iter.Err() != nil:
-		log.Warningf("spn/navigator: failed to (fully) initialize %s map: %s", m.Name, iter.Err())
+		return fmt.Errorf("failed to (fully) initialize %s map: %w", m.Name, iter.Err())
 	case hubCount == 0:
 		log.Warningf("spn/navigator: no hubs available for %s map - this is normal on first start", m.Name)
 	default:
 		log.Infof("spn/navigator: added %d hubs from database to %s map", hubCount, m.Name)
 	}
+	return nil
 }
 
 // UpdateHook updates the a map from database changes.

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -304,7 +304,7 @@ func (t *TerminalBase) submitToUpstream(msg *Msg, timeout time.Duration) {
 	msg.FlowID = t.ID()
 
 	// Debug unit leaks.
-	msg.Debug()
+	msg.debugWithCaller(2)
 
 	// Submit to upstream.
 	err := t.upstream.Send(msg, timeout)

--- a/unit/scheduler_stats.go
+++ b/unit/scheduler_stats.go
@@ -1,33 +1,87 @@
 package unit
 
-// GetAvgSlotPace returns the current average slot pace.
-func (s *Scheduler) GetAvgSlotPace() int64 {
-	// This is somewhat racy, as one value might already be updated with the
-	// latest slot data, while the other has been not.
-	// This is not so much of a problem, as slots are really short and the impact
-	// is very low.
-	cnt := s.avgPaceCnt.Load()
-	sum := s.avgPaceSum.Load()
+// Stats are somewhat racy, as one value of sum or count might already be
+// updated with the latest slot data, while the other has been not.
+// This is not so much of a problem, as slots are really short and the impact
+// is very low.
 
-	return sum / cnt
+// cycleStats calculates the new values and cycles the current values.
+func (s *Scheduler) cycleStats() {
+	// Get and reset max pace.
+	s.stats.current.maxPace.Store(s.stats.progress.maxPace.Load())
+	s.stats.progress.maxPace.Store(0)
+
+	// Get and reset max leveled pace.
+	s.stats.current.maxLeveledPace.Store(s.stats.progress.maxLeveledPace.Load())
+	s.stats.progress.maxLeveledPace.Store(0)
+
+	// Get and reset avg slot pace.
+	avgPaceCnt := s.stats.progress.avgPaceCnt.Load()
+	if avgPaceCnt > 0 {
+		s.stats.current.avgPace.Store(s.stats.progress.avgPaceSum.Load() / avgPaceCnt)
+	} else {
+		s.stats.current.avgPace.Store(0)
+	}
+	s.stats.progress.avgPaceCnt.Store(0)
+	s.stats.progress.avgPaceSum.Store(0)
+
+	// Get and reset avg unit life.
+	avgUnitLifeCnt := s.stats.progress.avgUnitLifeCnt.Load()
+	if avgUnitLifeCnt > 0 {
+		s.stats.current.avgUnitLife.Store(s.stats.progress.avgUnitLifeSum.Load() / avgUnitLifeCnt)
+	} else {
+		s.stats.current.avgUnitLife.Store(0)
+	}
+	s.stats.progress.avgUnitLifeCnt.Store(0)
+	s.stats.progress.avgUnitLifeSum.Store(0)
+
+	// Get and reset avg work slot duration.
+	avgWorkSlotCnt := s.stats.progress.avgWorkSlotCnt.Load()
+	if avgWorkSlotCnt > 0 {
+		s.stats.current.avgWorkSlot.Store(s.stats.progress.avgWorkSlotSum.Load() / avgWorkSlotCnt)
+	} else {
+		s.stats.current.avgWorkSlot.Store(0)
+	}
+	s.stats.progress.avgWorkSlotCnt.Store(0)
+	s.stats.progress.avgWorkSlotSum.Store(0)
+
+	// Get and reset avg catch up slot duration.
+	avgCatchUpSlotCnt := s.stats.progress.avgCatchUpSlotCnt.Load()
+	if avgCatchUpSlotCnt > 0 {
+		s.stats.current.avgCatchUpSlot.Store(s.stats.progress.avgCatchUpSlotSum.Load() / avgCatchUpSlotCnt)
+	} else {
+		s.stats.current.avgCatchUpSlot.Store(0)
+	}
+	s.stats.progress.avgCatchUpSlotCnt.Store(0)
+	s.stats.progress.avgCatchUpSlotSum.Store(0)
 }
 
-// ResetAvgSlotPace reset average slot pace values.
-func (s *Scheduler) ResetAvgSlotPace() {
-	// This is somewhat racy, as one value might already be updated with the
-	// latest slot data, while the other has been not.
-	// This is not so much of a problem, as slots are really short and the impact
-	// is very low.
-	s.avgPaceCnt.Store(1)
-	s.avgPaceSum.Store(s.config.MinSlotPace)
+// GetMaxSlotPace returns the current maximum slot pace.
+func (s *Scheduler) GetMaxSlotPace() int64 {
+	return s.stats.current.maxPace.Load()
 }
 
 // GetMaxLeveledSlotPace returns the current maximum leveled slot pace.
 func (s *Scheduler) GetMaxLeveledSlotPace() int64 {
-	return s.maxLeveledPace.Load()
+	return s.stats.current.maxLeveledPace.Load()
 }
 
-// ResetMaxLeveledSlotPace resets the maximum leveled slot pace value.
-func (s *Scheduler) ResetMaxLeveledSlotPace() {
-	s.maxLeveledPace.Store(0)
+// GetAvgSlotPace returns the current average slot pace.
+func (s *Scheduler) GetAvgSlotPace() int64 {
+	return s.stats.current.avgPace.Load()
+}
+
+// GetAvgUnitLife returns the current average unit lifetime until it is finished.
+func (s *Scheduler) GetAvgUnitLife() int64 {
+	return s.stats.current.avgUnitLife.Load()
+}
+
+// GetAvgWorkSlotDuration returns the current average work slot duration.
+func (s *Scheduler) GetAvgWorkSlotDuration() int64 {
+	return s.stats.current.avgWorkSlot.Load()
+}
+
+// GetAvgCatchUpSlotDuration returns the current average catch up slot duration.
+func (s *Scheduler) GetAvgCatchUpSlotDuration() int64 {
+	return s.stats.current.avgCatchUpSlot.Load()
 }

--- a/unit/unit_debug.go
+++ b/unit/unit_debug.go
@@ -43,6 +43,9 @@ func (s *Scheduler) StartDebugLog() {
 		units: make(map[int64]*UnitDebugData),
 	}
 
+	// Force StatCycleDuration to match the debug log output.
+	s.config.StatCycleDuration = time.Second
+
 	go func() {
 		for {
 			s.debugStep()
@@ -68,12 +71,16 @@ func (s *Scheduler) debugStep() {
 
 	// Print current state.
 	log.Debugf(
-		`scheduler: state: slotPace=%d avgPace=%d maxPace=%d currentUnitID=%d clearanceUpTo=%d`,
+		`scheduler: state: slotPace=%d avgPace=%d maxPace=%d maxLeveledPace=%d currentUnitID=%d clearanceUpTo=%d unitLife=%s slotDurations=%s/%s`,
 		s.slotPace.Load(),
-		s.avgPaceSum.Load()/s.avgPaceCnt.Load(),
-		s.maxLeveledPace.Load(),
+		s.GetAvgSlotPace(),
+		s.GetMaxSlotPace(),
+		s.GetMaxLeveledSlotPace(),
 		s.currentUnitID.Load(),
 		s.clearanceUpTo.Load(),
+		time.Duration(s.GetAvgUnitLife()).Round(10*time.Microsecond),
+		time.Duration(s.GetAvgWorkSlotDuration()).Round(10*time.Microsecond),
+		time.Duration(s.GetAvgCatchUpSlotDuration()).Round(10*time.Microsecond),
 	)
 	log.Debugf("scheduler: unit sources: %+v", sources)
 }

--- a/unit/unit_test.go
+++ b/unit/unit_test.go
@@ -20,6 +20,7 @@ func TestUnit(t *testing.T) { //nolint:paralleltest
 
 	// Create and start scheduler.
 	s := NewScheduler(&SchedulerConfig{})
+	s.StartDebugLog()
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		err := s.SlotScheduler(ctx)
@@ -58,20 +59,29 @@ func TestUnit(t *testing.T) { //nolint:paralleltest
 	time.Sleep(s.config.SlotDuration * 2)
 
 	// Print current state.
+	s.cycleStats()
 	fmt.Printf(`scheduler state:
 		currentUnitID = %d
 		slotPace = %d
 		clearanceUpTo = %d
 		finished = %d
-		avgPace = %d
 		maxPace = %d
+		maxLeveledPace = %d
+		avgPace = %d
+		avgUnitLife = %s
+		avgWorkSlot = %s
+		avgCatchUpSlot = %s
 `,
 		s.currentUnitID.Load(),
 		s.slotPace.Load(),
 		s.clearanceUpTo.Load(),
 		s.finished.Load(),
-		s.avgPaceSum.Load()/s.avgPaceCnt.Load(),
-		s.maxLeveledPace.Load(),
+		s.GetMaxSlotPace(),
+		s.GetMaxLeveledSlotPace(),
+		s.GetAvgSlotPace(),
+		time.Duration(s.GetAvgUnitLife()),
+		time.Duration(s.GetAvgWorkSlotDuration()),
+		time.Duration(s.GetAvgCatchUpSlotDuration()),
 	)
 
 	// Check if everything seems good.


### PR DESCRIPTION
- Fix scheduler slot skew and improve stats/metrics
- Fix ensuring matching IP stacks when finding nearest pins
- Check routes for failed hubs before building
- Ignore session to failing hubs and reset failings when re-connecting
- Retry to initialize map from DB if it fails
- Improve routing conditions
- Collect findnearest debug data and add api to test routing
